### PR TITLE
NCSDIS: Made --list the default

### DIFF
--- a/src/ncsdis.cpp
+++ b/src/ncsdis.cpp
@@ -182,6 +182,9 @@ void disNCS(const Common::UString &inFile, const Common::UString &outFile,
 			disassembler.createDot(*out, printControlTypes);
 			break;
 
+		case kCommandNone:
+			disassembler.createListing(*out, printStack);
+			break;
 		default:
 			throw Common::Exception("Invalid command %u", (uint)command);
 	}


### PR DESCRIPTION
Just changed the kCommandNone to have the same behavior as kCommandListing. Added it as its own separate case for readability. 