### PR TITLE
NCSDIS: Make --list actually be the default

### DIFF
--- a/src/ncsdis.cpp
+++ b/src/ncsdis.cpp
@@ -72,7 +72,7 @@ int main(int argc, char **argv) {
 		Aurora::GameID game = Aurora::kGameIDUnknown;
 
 		int returnValue = 1;
-		Command command = kCommandNone;
+		Command command = kCommandListing;
 		bool printStack = false;
 		bool printControlTypes = false;
 		Common::UString inFile, outFile;


### PR DESCRIPTION
The usage message for `ncsdis` notes that '--list' is the default command,
but if you omit it from your command line then we continue anyway with
kCommandNone.

So I think we should either do this, or actually complain early on if the user
doesn't specify a command.