### PR TITLE
NWN2: Fix broken, non-standard NWN2 XML files

### DIFF
--- a/src/aurora/xmlfix.cpp
+++ b/src/aurora/xmlfix.cpp
@@ -31,7 +31,6 @@
 
 /*
  * TODO:
- * - Add a test for a valid XML header
  * - Merge in revisions to UString.h
  * - Only run fixCopyright once?
  * - Check for other NWN2 XML issues
@@ -72,6 +71,13 @@ Common::SeekableReadStream *XMLFix::fixXMLStream(Common::SeekableReadStream *xml
 	// Create the output stream
 	Common::MemoryWriteStreamDynamic out;
 	out.reserve(xml->size());
+	
+	// Check for a standard header
+	xml->seek(0);
+	Common::UString line = Common::readStringLine(*xml, Common::kEncodingUTF8);
+	if (line.find("<?xml") != 0) {
+		throw Common::Exception("Input stream does not have a proper XML header");
+	}
 
 	try {
 		// Cycle through the input stream

--- a/src/aurora/xmlfix.cpp
+++ b/src/aurora/xmlfix.cpp
@@ -1,7 +1,33 @@
-//Converts NWN xml code to proper XML code.
-//Fixes unescaped special characters, root
-//Elements, mismatched nodes, unclosed 
-//Parentheses, and unclosed quotes.
+/* xoreos-tools - Tools to help with xoreos development
+ *
+ * xoreos-tools is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos-tools is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos-tools is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos-tools. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Fix broken, non-standard XML files.
+ */
+
+/**
+* This class converts NWN2 xml code to proper XML code.
+* It fixes unescaped special characters, root elements,
+* mismatched nodes, unclosed parentheses, and unclosed
+* quotes.
+*/
 
 #include <iostream>
 #include <string>
@@ -9,8 +35,8 @@
 #include <algorithm>
 #include <stdio.h>
 #include <ctype.h>
-#include "../common/ustring.h"
-#include "XMLFix.h"
+#include "src/common/ustring.h"
+#include "src/aurora/xmlfix.h"
 
 using std::cout;
 using std::string;
@@ -26,7 +52,10 @@ static Common::SeekableReadStream *fixXML(Common::SeekableReadStream *xml) {
 int main(int argc, char* argv[]) {
 	if (argc != 2) {
 		cout << "Please specify an xml file to parse.\n"
-			"a file name <fileName>Fixed will be created.\n";//TODO: update this when we no longer create new files. Double-check, but I believe we want to modify the original file, not create a new one. 
+			"a file name <fileName>Fixed will be created.\n";
+			// TODO: update this when we no longer create new files.
+			// Double-check, but I believe we want to modify the
+			// original file, not create a new one. 
 		return -1;
 	}
 	//First get our file names	

--- a/src/aurora/xmlfix.cpp
+++ b/src/aurora/xmlfix.cpp
@@ -31,10 +31,7 @@
 
 /*
  * TODO:
- * - Merge in revisions to UString.h
- * - Only run fixCopyright once?
  * - Check for other NWN2 XML issues
- * - Convert quotedCloseFix to use Common::UString
  * - Replace countOccurances with count()?
  * - Update fixOpenQuotes to ignore comments?
  * - Optimize for performance
@@ -57,16 +54,17 @@ using namespace Aurora;
 
 using std::string;
 
+const uint32 quote_mark = '\"';
+
 /**
  * This filter converts the contents of an NWN2 XML data
  * stream into standardized XML.
  */
 Common::SeekableReadStream *XMLFix::fixXMLStream(Common::SeekableReadStream &xml) {
 	Common::UString line;
-
+	
 	// Initialize the internal tracking variables
 	comCount = 0;
-	fixedXML = false;
 	fixedCopyright = false;
 	inUIButton = false;
 	
@@ -86,12 +84,17 @@ Common::SeekableReadStream *XMLFix::fixXMLStream(Common::SeekableReadStream &xml
 	out.reserve(xml.size());
 
 	try {
+		// Fix the header
+		xml.seek(0);
+		line = Common::readStringLine(xml, Common::kEncodingLatin9);
+		line = fixXMLTag(line) + "\n";
+		out.write(line.c_str(), line.size());
+
 		// Insert root element
 		const Common::UString startRoot = "<Root>\n";
 		out.write(startRoot.c_str(), startRoot.size());
 
-		// Cycle through the input stream
-		xml.seek(0);
+		// Cycle through the remaining input stream
 		while (!xml.eos()) {
 			// Read a line of text
 			line = Common::readStringLine(xml, Common::kEncodingLatin9);
@@ -99,15 +102,16 @@ Common::SeekableReadStream *XMLFix::fixXMLStream(Common::SeekableReadStream &xml
 			// Fix the XML format
 			if (line.size() > 0)
 				line = XMLFix::parseLine(line);
-			line += "\n"; // Stripped by readStringLine
 
 			// Copy to the output stream
+			line += "\n"; // Stripped by readStringLine
 			out.write(line.c_str(), line.size());
 		}
 
 		// Insert end root element
 		const Common::UString endRoot = "</Root>\n";
 		out.write(endRoot.c_str(), endRoot.size());
+
 	} catch (Common::Exception &e) {
 		e.add("Failed to fix XML stream");
 		throw e;
@@ -122,8 +126,6 @@ Common::SeekableReadStream *XMLFix::fixXMLStream(Common::SeekableReadStream &xml
 * Returns that fixed line.
 */
 Common::UString XMLFix::parseLine(Common::UString line) {
-	if (!fixedXML)
-		line = fixXMLTag(line);
 	line = fixUnclosedNodes(line);
 	line = escapeSpacedStrings(line, false); // Fix problematic strings (with spaces or special characters)
 	line = fixMismatchedParen(line);
@@ -187,9 +189,6 @@ Common::UString XMLFix::fixXMLTag(Common::UString line) {
 		const Common::UString badEncoding = "encoding=\"NWN2UI\"";
 		const Common::UString goodEncoding = "encoding=\"utf-8\"";
 		line = replaceText( line, badEncoding, goodEncoding );
-
-		// Flag as fixed
-		fixedXML = true;
 	}
 	return line;
 }
@@ -201,17 +200,21 @@ Common::UString XMLFix::fixXMLTag(Common::UString line) {
 * UIButton.
 */
 Common::UString XMLFix::fixUnclosedNodes(Common::UString line) {
-	size_t pos = line.find("<UIButton");
-	//Open node	
-	if (pos != string::npos) {
+	const Common::UString startButton = "<UIButton";
+	const Common::UString endButton = "</UIButton>";
+	
+	// Open node	
+	Common::UString::iterator pos = line.findFirst(startButton);
+	if (pos != line.end()) {
 		inUIButton = true;
 	}
-	pos = line.find("</UIButton>");
-	//Close node	
-	if (pos != string::npos) {
+	
+	// Close node	
+	pos = line.findFirst(endButton);
+	if (pos != line.end()) {
 		//If we aren't in a node, delete the close node.
 		if (!inUIButton) {
-			line.replace(pos, 11, "");
+			line = replaceText(line, endButton, "");
 		}
 		inUIButton = false;
 	}
@@ -226,35 +229,46 @@ Common::UString XMLFix::fixUnclosedNodes(Common::UString line) {
 * case we look for right now.
 */
 Common::UString XMLFix::escapeInnerQuotes(Common::UString line) {
-	const uint32 quote_mark = '\"';
-	if (countOccurances(line, quote_mark) > 2) {//We have more than 2 quotes in one line
-		size_t firstQuotPos = line.find("\""); //The first quotation mark
-		size_t lastQuotPos = line.find_last_of(quote_mark); //The last quotation mark
+	Common::UString::iterator pos;
+
+	if (countOccurances(line, quote_mark) > 2) {
+		// We have more than 2 quotes in one line
+		size_t firstQuotPos = line.getPosition(line.findFirst(quote_mark)); // First quote mark
+		size_t lastQuotPos = line.getPosition(line.findLast(quote_mark));   // Last quote mark
 		bool inPar = false;
 		for (size_t i = firstQuotPos + 1; i < lastQuotPos - 1; i++) {
 			// For a parenthetical, all quotes need to be replaced
 			// This is not covered by our previous cases if there are 
 			// multiple quoted entries in one set of parens.
-			uint32 c = line.at(1);
+			uint32 c = line.at(i);
 			if (c == '(') {
 				inPar = true;
 			} else if (c == ')') {
 				inPar = false;
 			} else if (inPar && c == '"') {
-				line.replace(i, 1, "&quot;");
-				lastQuotPos = line.find_last_of(quote_mark); // Update string length
+				pos = line.getPosition(i);
+				line.erase(pos);
+				pos = line.getPosition(i); // Avoid error throw
+				line.insert(pos, "&quot;");
+				lastQuotPos = line.getPosition(line.findLast(quote_mark)); // Updated string length
 			}
 			
 			c = line.at(i); // May have changed
 			uint32 d = line.at(i + 1);
 			if (c == '(' && d == '"') {
 				// Opening paren, encode the quote
-				line.replace(i + 1, 1, "&quot;");
-				lastQuotPos = line.find_last_of(quote_mark); // Our string changed, last quote should too.
+				pos = line.getPosition(i + 1);
+				line.erase(pos);
+				pos = line.getPosition(i + 1); // Avoid error throw
+				line.insert(pos, "&quot;");
+				lastQuotPos = line.getPosition(line.findLast(quote_mark)); // Updated string length
 			} else if ((c == '"' && d == ')') || (c == '"' && d == ',')) {
 				// Found a close paren or a comma [as in foo=("elem1",bar)], so encode the quote
-				line.replace(i, 1, "&quot;");
-				lastQuotPos = line.find_last_of(quote_mark); // Update string length
+				pos = line.getPosition(i);
+				line.erase(pos);
+				pos = line.getPosition(i); // Avoid error throw
+				line.insert(pos, "&quot;");
+				lastQuotPos = line.getPosition(line.findLast(quote_mark)); // Updated string length
 			}
 		}
 	}
@@ -294,7 +308,8 @@ Common::UString XMLFix::fixMismatchedParen(Common::UString line) {
 		} else if (i == pos - 1) {
 			// We're at the end of the string and haven't closed a paren.
 			if (c != ')') {
-				line.insert(pos, ")");
+				it = line.getPosition(pos);
+				line.insert(it, ")");
 				break;
 			}
 		}
@@ -308,12 +323,15 @@ Common::UString XMLFix::fixMismatchedParen(Common::UString line) {
 * and return the fixed line.
 */
 Common::UString XMLFix::fixOpenQuotes(Common::UString line) {
+	Common::UString::iterator pos;
+
 	// We have an equal with no open quote
 	size_t end = line.size() - 1;
 	for (size_t i = 0; i < end; i++) {
 		// Equal sign should be followed by a quote
 		if (line.at(1) == '=' && line.at(i + 1) != '"') {
-			line.insert(i + 1, "\"");
+			pos = line.getPosition(i + 1);
+			line.insert(pos, quote_mark);
 			i++; // Our string got longer.
 			end++;
 		}
@@ -322,7 +340,8 @@ Common::UString XMLFix::fixOpenQuotes(Common::UString line) {
 		// But if we replace it directly here, it will be doubly escaped
 		// because we run escapeInnerQuotes() next.
 		if (line.at(i) == '(' && line.at(i + 1) != '"' && line.at(i + 1) != ')') {
-			line.insert(i + 1, "\"");
+			pos = line.getPosition(i + 1);
+			line.insert(pos, quote_mark);
 			end++;
 		}
 
@@ -331,29 +350,34 @@ Common::UString XMLFix::fixOpenQuotes(Common::UString line) {
 		// in a 2 element parenthesis set. This is always a number. ("elem="foo",local=5)
 		// or when we have () empty.
 		if (i > 0 && line.at(i) == ')' && line.at(i - 1) != '"' && line.at(i - 1) != '(') {
-			line.insert(i, "\"");
+			pos = line.getPosition(i);
+			line.insert(pos, quote_mark);
 			end++;
 		}
 
 		// No quote before , add it in.
 		if (i > 0 && line.at(i) == ',' && line.at(i - 1) != '"') {
-			line.insert(i, "\"");
+			pos = line.getPosition(i);
+			line.insert(pos, quote_mark);
 			end++;
 		}
 
 		// No quote after a comma
 		if (line.at(i) == ',' && line.at(i + 1) != '"') {
-			line.insert(i + 1, "\"");
+			pos = line.getPosition(i + 1);
+			line.insert(pos, quote_mark);
 			end++;
 
 		}
 
 		// A close paren should be followed by a " or a space and a \>
-		if (i < end - 1 && line.at(i) == ')' && line.at(i + 2) != '\\') {
-			line.insert(i + 1, "\"");
-			i++; // Our string got longer.
-			end++;
-		}
+// Why? This adds a spurious " after a close parenthesis.
+//		if (i < end - 1 && line.at(i) == ')' && line.at(i + 2) != '\\') {
+//			pos = line.getPosition(i + 1);
+//			line.insert(pos, quote_mark);
+//			i++; // Our string got longer.
+//			end++;
+//		}
 	}
 
 	line = fixCloseBraceQuote(line);
@@ -369,13 +393,15 @@ Common::UString XMLFix::fixOpenQuotes(Common::UString line) {
 * odd number of quotes.
 */
 Common::UString XMLFix::fixUnevenQuotes(Common::UString line) {
-	size_t closeBrace = line.find("/>");
+	Common::UString::iterator pos = line.findFirst("/>");
+	size_t closeBrace = line.getPosition(pos);
+
 	// We don't have a close quote before our close brace
 	// Sometimes there is a space after a quote
-	if (closeBrace != string::npos && closeBrace > 0 &&
-		(line.at(closeBrace - 1) != '\"' || line.at(closeBrace - 2) != '\"') &&
-		countOccurances(line, '"') % 2) {
-		line.insert(closeBrace, "\"");
+	if (pos != line.end() && pos != line.begin() &&
+		(line.at(closeBrace - 1) != quote_mark || line.at(closeBrace - 2) != quote_mark) &&
+		countOccurances(line, quote_mark) % 2) {
+		line.insert(pos, quote_mark);
 	}
 	return line;
 }
@@ -388,31 +414,33 @@ Common::UString XMLFix::fixUnevenQuotes(Common::UString line) {
 * Removed in a later function (such as fixTripleQuote())
 */
 Common::UString XMLFix::fixUnclosedQuote(Common::UString line) {
+	const uint32 space = ' ';
 	bool inQuote = false; // Tracks if we are inside a quote
-	size_t end = line.length();
+	size_t end = line.size();
+
 	for (size_t i = 0; i < end; i++) {
 		uint32 c = line.at(i);
 		if (!inQuote) {
-			if (c == '"') {
+			if (c == quote_mark) {
 				inQuote = true;
 			}
 		} else {
 			// Inquote is true, we're in a quoted part.
-			if (c == '"') {
+			if (c == quote_mark) {
 				// This is a close quote
 				inQuote = false;
 
-				// A close quote should be followed by a space.
+				// A close quote should be followed by a space, slash, quote, or comma
 				uint32 d = line.at(i + 1);
-				if (d != ' ' && d != '/' && d != '"') {
-					line.insert(i + 1, " ");
+				if (d != space && d != '/' && d != quote_mark && d != ',') {
+					line.insert(line.getPosition(i + 1), space);
 					i++;
 					end++;
 				}
 			} else if (Common::UString::isSpace(c)) {
 				// We can't check for just a space, because files
 				// sometimes also contain newlines.
-				line.insert(i, "\"");
+				line.insert(line.getPosition(i), quote_mark);
 				i++;
 				end++;
 				inQuote = false;
@@ -427,24 +455,25 @@ Common::UString XMLFix::fixUnclosedQuote(Common::UString line) {
 * have a close quote and we see a />, we add a close quote.
 */
 Common::UString XMLFix::fixCloseBraceQuote(Common::UString line) {
-	bool inQuote = false;
-	size_t end = line.length();
-	for (size_t i = 0; i < end; i++) {
-		uint32 c = line.at(i);
-		if (!inQuote) {
-			if (c == '"') {
-				inQuote = true;
+	// Look for a tag close
+	Common::UString::iterator pos = line.findFirst("/>");
+	if (pos != line.end()) {
+		size_t end = line.getPosition(pos);
+		bool inQuote = false;
+
+		// Track the open/close state of the quotes
+		for (size_t i = 0; i < end; i++) {
+			uint32 c = line.at(i);
+			if (c == quote_mark) {
+				// Flip the quote state
+				inQuote = !inQuote;
 			}
-		} else {
-			size_t pos = line.find("/>");
-			if (c == '"') { // Inquote is true, we're in a quoted part.
-				inQuote = false;
-			} else if (pos != std::string::npos) {
-				if (line.at(pos - 1) != '"') {
-					line.insert(pos, "\"");
-					break;
-				}
-			}
+		}
+
+		// Check for an open quote at the end
+		if (inQuote) {
+			// Insert a close quote
+			line.insert(pos, quote_mark);
 		}
 	}
 	return line;
@@ -457,12 +486,18 @@ Common::UString XMLFix::fixCloseBraceQuote(Common::UString line) {
 * compatibility.
 */
 Common::UString XMLFix::doubleDashFix(Common::UString line) {
-	size_t pos = line.find("--");
+	Common::UString::iterator first = line.findFirst("--");
 
-	// It's not a comment
-	if (pos < line.length() - 1 && line.at(pos + 2) != '>' && (pos > 0 && line.at(pos - 1) != '!')) {
-		// Remove one dash
-		line.erase(pos, 1);
+	// Does the line have a '--'?
+	if (first != line.end()) {
+		size_t pos = line.getPosition(first);
+
+		// It's not a comment
+		if (pos < line.size() - 1 && line.at(pos + 2) != '>' && (pos > 0 && line.at(pos - 1) != '!')) {
+			// Remove one dash
+			Common::UString::iterator it = line.getPosition(pos);
+			line.erase(it);
+		}
 	}
 	return line;
 }
@@ -480,17 +515,20 @@ Common::UString XMLFix::doubleDashFix(Common::UString line) {
 * Triple quotes.
 */
 Common::UString XMLFix::tripleQuoteFix(Common::UString line) {
-	size_t pos = line.find("\"\"\"");
-	if (pos != std::string::npos) {
-		line.erase(pos, 2); //Remove two quotes.
+	Common::UString::iterator startPos = line.findFirst("\"\"\"");
+	if (startPos != line.end()) {
+		Common::UString::iterator endPos = line.getPosition(line.getPosition(startPos) + 2);
+		line.erase(startPos, endPos); //Remove two quotes.
 	}
 
 	// Might as well escape "" as well, while we're at it.
-	if (line.find("name=\"\"") == std::string::npos) {
+	startPos = line.findFirst("name=\"\"");
+	if (startPos == line.end()) {
 		// The line doesn't contain name=""	
-		pos = line.find("\"\"");
-		if (pos != std::string::npos) {
-			line.erase(pos, 2);// Remove one quote.
+		startPos = line.findFirst("\"\"");
+		if (startPos != line.end()) {
+			Common::UString::iterator endPos = line.getPosition(line.getPosition(startPos) + 1);
+			line.erase(startPos, endPos); // Remove one quote.
 		}
 	} return line;
 }
@@ -510,13 +548,9 @@ Common::UString XMLFix::replaceText(Common::UString line,
 		size_t width = badStr.size();
 		Common::UString::iterator endPos = line.getPosition(pos + width);
 		
-		// Remove the badStr instance
-		line.erase(startPos, endPos);
-		
-		// Regenerate iterator to avoid throwing an exception
-		startPos = line.getPosition(pos);
-		
 		// Replace badStr with goodStr
+		line.erase(startPos, endPos);
+		startPos = line.getPosition(pos); // Avoid throwing error
 		line.insert(startPos, goodStr);
 
 		// Look for another instance
@@ -567,14 +601,21 @@ Common::UString XMLFix::escapeSpacedStrings(Common::UString line, bool undo) {
 }
 
 /**
-* Track number of open and closed comments
+* Track number of open and closed HTML comments, one per line
 * Used for tracking copyright.
 */
 void XMLFix::countComments(Common::UString line) {
-	if (line.find("<!--") != std::string::npos) {
+	Common::UString::iterator pos;
+
+	// Start of a comment
+	pos = line.findFirst("<!--");
+	if (pos != line.end()) {
 		comCount++;
 	}
-	if (line.find("-->") != std::string::npos) {
+
+	// End of a comment
+	pos = line.findFirst("-->");
+	if (pos != line.end()) {
 		comCount--;
 	}
 }
@@ -582,26 +623,38 @@ void XMLFix::countComments(Common::UString line) {
 /**
 * If we have a "/>", replace it with a />
 * If we have a />", replace it with a />
-* If we have a >", replace it with a ">
+* If we have a >", replace it with a >
 * This function is another instance of
 * cleaning up after ourselves.
 */
 Common::UString XMLFix::quotedCloseFix(Common::UString line) {
-	// For now, just use std::string calls
-	std::string sline = line.c_str();
-	size_t pos = sline.find("\"/>\"");
-	if (pos != std::string::npos) {
-		sline.erase(pos, 1);
-		sline.erase(pos + 2, 1);
+	Common::UString::iterator pos;
+	size_t n;
+
+	// Remove quotes from: "/>"
+	pos = line.findFirst("\"/>\"");
+	if (pos != line.end()) {
+		n = line.getPosition(pos);
+		line.erase(pos);
+		pos = line.getPosition(n + 2);
+		line.erase(pos);
 	}
-	pos = sline.find("/>\"");
-	if (pos != std::string::npos) {
-		sline.erase(pos + 2, 1);
+
+	// Remove quote from: />"
+	pos = line.findFirst("/>\"");
+	if (pos != line.end()) {
+		n = line.getPosition(pos);
+		pos = line.getPosition(n + 2);
+		line.erase(pos);
 	}
-	pos = sline.find(">\"");
-	if (pos != std::string::npos) {
-		sline.erase(pos + 1, 1);
-		sline.insert(pos, "\"");
+
+	// Remove quote from: >"
+	pos = line.findFirst(">\"");
+	if (pos != line.end()) {
+		n = line.getPosition(pos);
+		pos = line.getPosition(n + 1);
+		line.erase(pos);
 	}
-	return (Common::UString)sline;
+
+	return line;
 }

--- a/src/aurora/xmlfix.cpp
+++ b/src/aurora/xmlfix.cpp
@@ -1,0 +1,530 @@
+//Converts NWN xml code to proper XML code.
+//Fixes unescaped special characters, root
+//Elements, mismatched nodes, unclosed 
+//Parentheses, and unclosed quotes.
+
+#include <iostream>
+#include <string>
+#include <fstream>
+#include <algorithm>
+#include <stdio.h>
+#include <ctype.h>
+#include "../common/ustring.h"
+#include "XMLFix.h"
+
+using std::cout;
+using std::string;
+
+int comCount = 0; //Track number of open/closed comments.
+bool inUIButton = false; //Used to fix </UIButton> tags that are never opened. 
+
+static Common::SeekableReadStream *fixXML(Common::SeekableReadStream *xml) {
+	//TODO
+	return nullptr;
+}
+
+int main(int argc, char* argv[]) {
+	if (argc != 2) {
+		cout << "Please specify an xml file to parse.\n"
+			"a file name <fileName>Fixed will be created.\n";//TODO: update this when we no longer create new files. Double-check, but I believe we want to modify the original file, not create a new one. 
+		return -1;
+	}
+	//First get our file names	
+	Common::UString oldFileName = argv[1];
+	Common::UString newFileName = oldFileName;
+	Common::UString line; //Each line of XML we parse
+	size_t perLoc = oldFileName.find("."); //Location of period in the file name.
+										   //There is a period	
+	if (perLoc != std::string::npos) {//Add Fixed before the extension
+		newFileName.insert(perLoc, "Fixed");
+	}
+	else {//Add Fixed at the end of the file
+		newFileName = newFileName + "Fixed";
+	}
+	//Then open the actual files. (converted to CStrings so fstream won't complain).
+	ifstream readFile(oldFileName.c_str(), ios::in);
+	if (!readFile.is_open()) {//We check twice so that we don't create files if garbage is passed in.
+		cout << "Error opening files." << endl;
+		return -1;
+	}
+	ofstream writeFile(newFileName.c_str(), ios::out | ios::trunc);//Create or overwrite
+	if (!writeFile.is_open()) {
+		cout << "Error opening files." << endl;
+		return -1;
+	}
+	//Check for XML style
+	if (getline(readFile, line)) {
+		if (trim(line).find("<?xml") == 0) {//If we start with an XML formatter
+											//Write this line first.
+			line = fixXMLTag(line);
+			writeFile << line << "\n";
+		}
+		else {
+			cout << "Improper XML file.\n";
+			return -1;
+		}
+	}
+	else {
+		cout << "Error reading file\n";
+		return -1;
+	}
+	//Then insert the root element.
+	writeFile << "<Root>\n";
+	while (getline(readFile, line)) {
+		countComments(line);
+		writeFile << parseLine(line) << "\n";
+	}
+	writeFile << "</Root>\n";
+	readFile.close();
+	writeFile.close();
+	return 0;
+}
+
+/**Read and fix any line of XML that is passed in,
+* Returns that fixed line.
+*/
+Common::UString parseLine(Common::UString line) {
+	line = fixUnclosedNodes(line);
+	line = escapeSpacedStrings(line, false);//Fix problematic strings (with spaces or special characters)
+	line = fixMismatchedParen(line);
+	line = fixOpenQuotes(line);//It's imperative that this run before the copyright line, or not on it at all. Could update to ignore comments.
+	line = escapeInnerQuotes(line);
+	line = fixCopyright(line); //Does this need to run EVERY line? //Worst case improvement, we could have a global variable for whether or not we've found it, and just run it once per file, on the assumption that it will only appear once per file.
+	line = doubleDashFix(line);
+	line = quotedCloseFix(line);
+	line = tripleQuoteFix(line);
+	line = escapeSpacedStrings(line, true); //Restore the problematic strings to their proper values.
+	return line;
+}
+
+/**
+* Removes copyright sign, as it is invalid
+* Unicode that xmllint doesn't like.
+* This probably doesn't need to run on every
+* Line.
+*/
+Common::UString fixCopyright(Common::UString line) {
+	//If this is the copyright line, remove the unicode.
+	if (line.find("Copyright") != std::string::npos) {
+		if (!comCount) {
+			return "<!-- Copyright 2006 Obsidian Entertainment, Inc. -->";
+		}
+		else {//If we're in a comment, don't add a new one.
+			return "Copyright 2006 Obsidian Entertainment, Inc.";
+		}//This may not be a perfect match (in the else case), but it gets the point across.
+	}
+	return line;
+}
+
+/**Corrects improper opening XML tags.
+* An improper XML tag has <xml instead
+* Of <?xml.
+* Also changes references to NWN2UI to
+* XML so xml-lint reads it properly.
+* Returns the unmodified line with the
+* Proper opening XML tag.
+*/
+Common::UString fixXMLTag(Common::UString line) {
+	//Let's ensure we close this properly.
+	if (line.find("<?xml") != string::npos) {
+		line = trim(line);
+		if (line.at(line.length() - 2) != '?') {
+			line.insert(line.length() - 1, "?");
+		}//NWN2UI is not a supported format. changing it to xml appears to work.
+		if (line.find("encoding=\"NWN2UI\"") != std::string::npos) {
+			return "<?xml version=\"1.0\" encoding=\"utf-8\"?>";
+		}
+	}
+	return line;
+}
+
+/**
+* If there is a close node without an open node
+* This will delete it. Right now it only works
+* If there is a closed UIButton without an open
+* UIButton.
+*/
+Common::UString fixUnclosedNodes(Common::UString line) {
+	size_t pos = line.find("<UIButton");
+	//Open node	
+	if (pos != string::npos) {
+		inUIButton = true;
+	}
+	pos = line.find("</UIButton>");
+	//Close node	
+	if (pos != string::npos) {
+		//If we aren't in a node, delete the close node.
+		if (!inUIButton) {
+			line.replace(pos, 11, "");
+		}
+		inUIButton = false;
+	}
+	return line;
+}
+
+/**
+* Finds and escapes quotes in an element,
+* Returns a fixed line.
+* The only time we're seeing faulty quotes is
+* In the context open("FooBar"), so that's the only
+* Case we look for right now.
+*/
+Common::UString escapeInnerQuotes(Common::UString line) {
+	if (countOccurances(line, '"') > 2) {//We have more than 2 quotes in one line
+		size_t firstQuotPos = line.find("\""); //The first quotation mark
+		size_t lastQuotPos = line.find_last_of("\""); //The last quotation mark
+		bool inPar = false;
+		for (size_t i = firstQuotPos + 1; i < lastQuotPos - 1; i++) {
+			//We're in a parenthetical, all quotes need to be replaced
+			//This is not covered by our previous cases if there are 
+			//Multiple quoted entries in one set of parens.
+			if (line.at(i) == '(') {
+				inPar = true;
+			}
+			else if (line.at(i) == ')') {
+				inPar = false;
+			}
+			else if (inPar && line.at(i) == '"') {
+				line.replace(i, 1, "&quot;");
+				lastQuotPos = line.find_last_of("\""); //Update string length
+			}if (line.at(i) == '(' && line.at(i + 1) == '"') {//Opening paren, encode the quote
+				line.replace(i + 1, 1, "&quot;");
+				lastQuotPos = line.find_last_of("\""); //Our string changed, last quote should too.
+			}
+			//If we have a close paren or a comma [as in foo=("elem1",bar)]
+			//Closed paren, encode the quote
+			else if ((line.at(i) == '"' && line.at(i + 1) == ')') || (line.at(i) == '"' && line.at(i + 1) == ',')) {
+				line.replace(i, 1, "&quot;");
+				lastQuotPos = line.find_last_of("\""); //Update string length
+			}
+		}
+	}
+	return line;
+}
+
+/**
+* Counts the number of times a character, find,
+* Appears in a string, line, and returns that
+* Number. //TODO: can we replace this with std::count?
+*/
+int countOccurances(Common::UString, char find) {
+	int count = 0;
+	for (size_t i = 0; i < line.length(); i++) {
+		if (line[i] == find) {
+			count++;
+		}
+	}
+	return count;
+}
+
+//Adds a closing paren if a line is missing such a thing.
+Common::UString fixMismatchedParen(Common::UString line) {
+	bool inParen = false;
+	size_t end = line.length();
+	for (size_t i = 0; i < end; i++) {
+		if (!inParen) {
+			if (line[i] == '(') {
+				inParen = true;
+			}
+		}
+		else {
+			size_t pos = line.find("/>");
+			if (line[i] == ')') {
+				inParen = false;
+			}
+			else if (i == pos - 1) {//We're at the end of the string and haven't closed a paren.
+				if (line.at(pos - 1) != ')') {
+					line.insert(pos, ")");
+					break;
+				}
+			}
+		}
+	}
+	return line;
+}
+
+/*
+* Find any element that has an equal sign not followed
+* By a quotation mark. Insert that quotation mark,
+* and return the fixed line.
+*/
+Common::UString fixOpenQuotes(Common::UString line) {
+	//We have an equal with no open quote
+	size_t end = line.length() - 1;
+	for (size_t i = 0; i < end; i++) {
+		//Equal sign should be followed by a quote
+		if (line.at(i) == '='&& line.at(i + 1) != '"') {
+			line.insert(i + 1, "\"");
+			i++;//Our string got longer.
+			end++;
+		}
+
+		//Open paren should be followed by a &quot; (or an immediate close paren)
+		//But if we replace it directly here, it will be doubly escaped
+		//Because we run escapeInnerQuotes() next.
+		if (line.at(i) == '(' && line.at(i + 1) != '"' && line.at(i + 1) != ')') {
+			line.insert(i + 1, "\"");
+			end++;
+		}
+
+		//A closed quote should be preceeded by &quot; See above.
+		//There are some exceptions to this, like when we have one quoted element
+		//In a 2 element parenthesis set. This is always a number. ("elem="foo",local=5)
+		//Or when we have () empty.
+		if (i > 0 && line.at(i) == ')' && line.at(i - 1) != '"' && line.at(i - 1) != '(') {
+			line.insert(i, "\"");
+			end++;
+		}
+
+		//No quote before , add it in.
+		if (i > 0 && line.at(i) == ',' && line.at(i - 1) != '"') {
+			line.insert(i, "\"");
+			end++;
+		}
+
+		//No quote after a comma
+		if (line.at(i) == ',' && line.at(i + 1) != '"') {
+			line.insert(i + 1, "\"");
+			end++;
+
+		}
+
+		//A close paren should be followed by a " or a space and a \>
+		if (i < end - 1 && line.at(i) == ')'&& line.at(i + 2) != '\\') {
+			line.insert(i + 1, "\"");
+			i++;//Our string got longer.
+			end++;
+		}
+	}
+
+	line = fixCloseBraceQuote(line);
+	line = fixUnclosedQuote(line);
+	line = fixUnevenQuotes(line);
+
+	return line;
+}
+
+/**
+* If a close brace exists (not a comment),
+* there isn't a close quote, AND we have an
+* odd number of quotes.
+*/
+Common::UString fixUnevenQuotes(Common::UString line) {
+	size_t closeBrace = line.find("/>");
+	//We don't have a close quote before our close brace
+	//Sometimes there is a space after a quote
+	if (closeBrace != string::npos && closeBrace > 0 &&
+		(line.at(closeBrace - 1) != '\"' || line.at(closeBrace - 2) != '\"') &&
+		countOccurances(line, '"') % 2) {
+		line.insert(closeBrace, "\"");
+	}
+	return line;
+}
+
+/**
+* After all of this, if we can iterate through a string
+* And find a quote followed by a whitespace character, insert a quote.
+* Preconditions are such that this should never occur naturally at this
+* Point in the code, and if we do end up adding too many, it will be
+* Removed in a later function (such as fixTripleQuote())
+*/
+std::string fixUnclosedQuote(std::string line) {
+	bool inQuote = false; //Tracks if we are inside a quote
+	size_t end = line.length();
+	for (size_t i = 0; i < end; i++) {
+		if (!inQuote) {
+			if (line[i] == '"') {
+				inQuote = true;
+			}
+		}
+		else {
+			if (line[i] == '"') {//Inquote is true, we're in a quoted part.
+				inQuote = false; //This is a close quote
+								 //A close quote should be followed by a space.
+				if (line.at(i + 1) != ' ' && line.at(i + 1) != '/' && line.at(i + 1) != '"') {
+					line.insert(i + 1, " ");
+					i++;
+					end++;
+				}
+			}
+			else if (isspace(line[i])) {//We can't check for just a space, 
+										//because files sometimes also contain newlines.
+				line.insert(i, "\"");
+				i++;
+				end++;
+				inQuote = false;
+			}
+		}
+	}
+	return line;
+}
+
+/**
+* Another close brace fix. If we're in a quote and we don't
+* have a close quote and we see a />, we add a close quote.
+*/
+std::string fixCloseBraceQuote(std::string line) {
+	bool inQuote = false;
+	size_t end = line.length();
+	for (size_t i = 0; i < end; i++) {
+		if (!inQuote) {
+			if (line[i] == '"') {
+				inQuote = true;
+			}
+		}
+		else {
+			size_t pos = line.find("/>");
+			if (line[i] == '"') {//Inquote is true, we're in a quoted part.
+				inQuote = false;
+			}
+			else if (pos != std::string::npos) {
+				if (line.at(pos - 1) != '"') {
+					line.insert(pos, "\"");
+					break;
+				}
+			}
+		}
+	}
+	return line;
+}
+
+/**
+* If there are any -- inside of a comment,
+* This will remove them and replace it with
+* A single dash. Otherwise this breaks
+* Compatibility.
+*/
+std::string doubleDashFix(std::string line) {
+	size_t pos = line.find("--");
+	//It's not a comment
+	if (pos < line.length() - 1 && line.at(pos + 2) != '>' && (pos > 0 && line.at(pos - 1) != '!')) {
+		line.erase(pos, 1);//Remove one dash.
+	}
+	return line;
+}
+
+/**
+* If there are three consecutive quotes,
+* Replace with one quote.
+* Let's be honest, this can only happen as a
+* Result of other methods, and this is a kludgy fix.
+* Note that this will only find one per line.
+* This will also remove double quotes that are not
+* Intended to be in the XML. name="" is the only
+* Legitimate appearance of "" in the NWN xml code.
+* Returns the modified line, without double or
+* Triple quotes.
+*/
+std::string tripleQuoteFix(std::string line) {
+	size_t pos = line.find("\"\"\"");
+	if (pos != std::string::npos) {
+		line.erase(pos, 2);//Remove two quotes.
+	}
+
+	//Might as well escape "" as well, while we're at it.
+	if (line.find("name=\"\"") == std::string::npos) {//If the line doesn't contain name=""	
+		pos = line.find("\"\"");
+		if (pos != std::string::npos) {
+			line.erase(pos, 2);//Remove one quote.
+		}
+	}
+	return line;
+}
+
+/**
+* Some lines contain problematic phrases. (phrases that include
+* String literals with spaces or the > or / characters).
+* If left untouched, other functions will destroy these strings
+* Instead of fixing them.
+* Returns a safe string (devoid of problematic phrases) if undo is false, or
+* The original string, with problematic phrases restored if undo is true.
+*/
+std::string escapeSpacedStrings(std::string line, bool undo) {
+	//Just used as containers.
+	//Might be an easier/cleaner way to do this, perhaps with some sort of map instead of two arrays.
+	string switchWordsFrom[] = { "portrait frame" , "0 / 0 MB", "->", ">>",
+		"capturemouseevents=false", "Speaker Name", " = ", "Player Chat" };
+	string switchWordsTo[] = { "portrait_frame" , "0_/_0_MB", "ReplaceMe1",
+		"ReplaceMe2","capturemouseevents=false ", "Speaker_Name", "=", "Player_Chat" };
+
+	//The arrays we actually reference
+	string * fromTemp = switchWordsFrom;
+	string * toTemp = switchWordsTo;
+	//Swap
+	//No need to switch the first time, but The second time we
+	//Call this, we want to switch from safe to original strings
+	if (undo) {
+		//Native array swap wasn't introduced until c++ 2011
+		//So we do this with pointers.	
+		string * swapTemp = fromTemp;
+		fromTemp = toTemp;
+		toTemp = swapTemp;
+	}
+	//Number of elements in the array.
+	int length = sizeof(switchWordsFrom) / sizeof(switchWordsFrom[0]);
+	//Do the actual replacement inline.	
+	for (int i = 0; i < length; i++) {
+		size_t pos = line.find(*(fromTemp + i));
+		if (pos != std::string::npos) {
+			line.replace(pos, (fromTemp + i)->length(), *(toTemp + i));
+		}
+	}
+	return line;
+}
+
+/**
+* Track number of open and closed comments
+* Used for tracking copyright.
+*/
+void countComments(std::string line) {
+	if (line.find("<!--") != std::string::npos)
+	{
+		comCount++;
+	}
+	if (line.find("-->") != std::string::npos)
+	{
+		comCount--;
+	}
+}
+
+//TODO replace this with Common::UString.trim()
+/**
+* Remove leading and trailing whitespace.
+* Returns line without leading and trailing
+* Spaces.
+*/
+std::string trim(std::string line) {
+	string whitespace = " \t\n\v\f\r";
+	size_t lineBegin = line.find_first_not_of(whitespace);
+	if (lineBegin == std::string::npos) {
+		return ""; //empty string
+	}
+	int lineEnd = line.find_last_not_of(whitespace);
+	int lineRange = lineEnd - lineBegin + 1;
+	return line.substr(lineBegin, lineRange);
+}
+
+/**
+* If we have a "/>", replace it with a />
+* If we have a />", raplce it with a />
+* If we have a >", replace it with a ">
+* This function is another instance of
+* Cleaning up after ourselves.
+*/
+std::string quotedCloseFix(std::string line) {
+	size_t pos = line.find("\"/>\"");
+	if (pos != std::string::npos) {
+		line.erase(pos, 1);
+		line.erase(pos + 2, 1);
+	}
+	pos = line.find("/>\"");
+	if (pos != std::string::npos) {
+		line.erase(pos + 2, 1);
+	}
+	pos = line.find(">\"");
+	if (pos != std::string::npos) {
+		line.erase(pos + 1, 1);
+		line.insert(pos, "\"");
+	}
+	return line;
+}

--- a/src/aurora/xmlfix.cpp
+++ b/src/aurora/xmlfix.cpp
@@ -291,7 +291,7 @@ Common::UString XMLFix::fixUnclosedNodes(Common::UString line) {
 	// Close node	
 	pos = line.findFirst(endButton);
 	if (pos != line.end()) {
-		//If we aren't in a node, delete the close node.
+		// If we aren't in a node, delete the close node.
 		if (!_inUIButton) {
 			line = replaceText(line, endButton, "");
 		}
@@ -660,8 +660,8 @@ Common::UString XMLFix::commentFix(Common::UString line) {
 		
 		// Not a full utf-8 check, but it works for the stock files
 		if (c & 0x8000) {
-			// Discard this character
-			Common::UString::iterator it = line.getPosition(i);
+			// Discard this character and recheck position
+			Common::UString::iterator it = line.getPosition(i--);
 			line.erase(it);
 		}
 	}

--- a/src/aurora/xmlfix.cpp
+++ b/src/aurora/xmlfix.cpp
@@ -249,10 +249,18 @@ Common::UString XMLFix::fixXMLTag(Common::UString line) {
 	// Check for an xml tag
 	Common::UString::iterator pos = line.findFirst("<?xml");
 	if (pos != line.end()) {
-		// Ensure we close this properly.
 		line.trim();
-		if (line.at(line.size() - 2) != '?') {
-			pos = line.getPosition(line.size() - 1);
+
+		// Fix for SlimGUI fontFamily.xml
+		pos = line.findFirst("<?xml"); // Regenerate with changed string
+		if (line.getPosition(pos) > 0) {
+			line.erase(line.begin(), pos);
+		}
+
+		// Ensure we close this properly.
+		int n = (int)line.size() - 2;
+		if (n > -1 && line.at(n) != '?') {
+			pos = line.getPosition(n+1);
 			line.insert(pos, '?');
 		}
 

--- a/src/aurora/xmlfix.cpp
+++ b/src/aurora/xmlfix.cpp
@@ -61,30 +61,29 @@ using std::string;
  * This filter converts the contents of an NWN2 XML
  * data stream into standardized XML.
  */
-Common::SeekableReadStream *XMLFix::fixXMLStream(Common::SeekableReadStream *xml) {
-	assert(xml);
-	
+Common::SeekableReadStream *XMLFix::fixXMLStream(Common::SeekableReadStream &xml) {
+	Common::UString line;
+
 	// Initialize the internal tracking variables
 	comCount = 0;
 	inUIButton = false;
 	
+	// Check for a standard header
+	xml.seek(0);
+	line = Common::readStringLine(xml, Common::kEncodingUTF8);
+	if (line.find("<?xml") != 0) 
+		throw Common::Exception("Input stream does not have a proper XML header");
+	
 	// Create the output stream
 	Common::MemoryWriteStreamDynamic out;
-	out.reserve(xml->size());
-	
-	// Check for a standard header
-	xml->seek(0);
-	Common::UString line = Common::readStringLine(*xml, Common::kEncodingUTF8);
-	if (line.find("<?xml") != 0) {
-		throw Common::Exception("Input stream does not have a proper XML header");
-	}
+	out.reserve(xml.size());
 
 	try {
 		// Cycle through the input stream
-		xml->seek(0);
-		while (!xml->eos()) {
+		xml.seek(0);
+		while (!xml.eos()) {
 			// Read a line of text
-			Common::UString line = Common::readStringLine(*xml, Common::kEncodingUTF8);
+			line = Common::readStringLine(xml, Common::kEncodingUTF8);
 
 			// Fix the XML format
 			line = XMLFix::parseLine(line);

--- a/src/aurora/xmlfix.h
+++ b/src/aurora/xmlfix.h
@@ -40,20 +40,22 @@ class XMLFix {
 public:
 	static Common::SeekableReadStream *fixXML(Common::SeekableReadStream *xml);
 
+	// Temporary public/static for testing because they're called from main()
+	Common::UString fixXMLTag(Common::UString line);
+	Common::UString parseLine(Common::UString line);
+
 private:
 	Common::UString fixLine(Common::UString line);
-	Common::UString parseLine(Common::UString line);
 	Common::UString trim(Common::UString line);
 	Common::UString fixOpenQuotes(Common::UString line);
 	Common::UString escapeInnerQuotes(Common::UString line);
 	Common::UString replaceString(Common::UString& origStr, Common::UString& oldText, Common::UString newText);
 	void replaceAll(Common::UString& str, const Common::UString& from, const Common::UString& to);
 	int countOccurances(Common::UString line, char find);
+	void countComments(std::string line);
 	Common::UString fixCopyright(Common::UString line);
-	Common::UString fixXMLTag(Common::UString line);
 	Common::UString doubleDashFix(Common::UString line);
 	Common::UString tripleQuoteFix(Common::UString line);
-	void countComments(std::string line);
 	Common::UString quotedCloseFix(Common::UString line);
 	Common::UString escapeSpacedStrings(Common::UString line, bool undo);
 	Common::UString fixMismatchedParen(Common::UString line);

--- a/src/aurora/xmlfix.h
+++ b/src/aurora/xmlfix.h
@@ -1,0 +1,42 @@
+#include <iostream>
+#include <string>
+
+namespace Common {
+	class Ustring;
+	class SeekableReadStream;
+}
+
+namespace Aurora {
+
+class XMLFix { 
+
+public:
+	static Common::SeekableReadStream *fixXML(Common::SeekableReadStream *xml);
+
+private:
+	Common::UString fixLine(Common::UString line);
+	Common::UString parseLine(Common::UString line);
+	Common::UString trim(Common::UString line);
+	Common::UString fixOpenQuotes(Common::UString line);
+	Common::UString escapeInnerQuotes(Common::UString line);
+	Common::UString replaceString(Common::UString& origStr, Common::UString& oldText, Common::UString newText);
+	void replaceAll(Common::UString& str, const Common::UString& from, const Common::UString& to);
+	int countOccurances(Common::UString line, char find);
+	Common::UString fixCopyright(Common::UString line);
+	Common::UStringg fixXMLTag(Common::UString line);
+	Common::UString doubleDashFix(Common::UString line);
+	Common::UString tripleQuoteFix(Common::UString line);
+	void countComments(std::string line);
+	Common::UString quotedCloseFix(Common::UString line);
+	Common::UString escapeSpacedStrings(Common::UString line, bool undo);
+	Common::UString fixMismatchedParen(Common::UString line);
+	Common::UString fixCloseBraceQuote(Common::UString line);
+	Common::UString fixUnclosedQuote(Common::UString line);
+	Common::UString fixUnevenQuotes(Common::UString line);
+	Common::UString fixUnclosedNodes(Common::UString line);
+
+};
+
+} // End of namespace Aurora
+
+

--- a/src/aurora/xmlfix.h
+++ b/src/aurora/xmlfix.h
@@ -1,3 +1,30 @@
+/* xoreos-tools - Tools to help with xoreos development
+ *
+ * xoreos-tools is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos-tools is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos-tools is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos-tools. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Fix broken, non-standard XML files.
+ */
+
+#ifndef AURORA_XMLFIX_H
+#define AURORA_XMLFIX_H
+
 #include <iostream>
 #include <string>
 
@@ -23,7 +50,7 @@ private:
 	void replaceAll(Common::UString& str, const Common::UString& from, const Common::UString& to);
 	int countOccurances(Common::UString line, char find);
 	Common::UString fixCopyright(Common::UString line);
-	Common::UStringg fixXMLTag(Common::UString line);
+	Common::UString fixXMLTag(Common::UString line);
 	Common::UString doubleDashFix(Common::UString line);
 	Common::UString tripleQuoteFix(Common::UString line);
 	void countComments(std::string line);
@@ -39,4 +66,4 @@ private:
 
 } // End of namespace Aurora
 
-
+#endif // AURORA_XMLFIX_H

--- a/src/aurora/xmlfix.h
+++ b/src/aurora/xmlfix.h
@@ -40,7 +40,7 @@ namespace Aurora {
 class XMLFix { 
 
 public:
-	Common::SeekableReadStream *fixXMLStream(Common::SeekableReadStream *xml);
+	Common::SeekableReadStream *fixXMLStream(Common::SeekableReadStream &xml);
 
 	// Temporarily public for testing because they're called from fix2xml
 	Common::UString fixXMLTag(Common::UString line);

--- a/src/aurora/xmlfix.h
+++ b/src/aurora/xmlfix.h
@@ -42,19 +42,19 @@ class XMLFix {
 public:
 	Common::SeekableReadStream *fixXMLStream(Common::SeekableReadStream &xml);
 
-	// Temporarily public for testing because they're called from fix2xml
-	Common::UString fixXMLTag(Common::UString line);
-	Common::UString parseLine(Common::UString line);
-
 private:
-	int comCount = 0;        // Track the number of open/closed comments
-	bool inUIButton = false; // Used to fix </UIButton> tags that were never opened
+	int  comCount = 0;        	// Track the number of open/closed comments
+	bool fixedXML = false;   	// Track if xml tag is fixed
+	bool fixedCopyright = false;	// Track if the copyright character is fixed
+	bool inUIButton = false; 	// Used to fix </UIButton> tags that were never opened
 
 	void replaceAll(Common::UString& str, const Common::UString& from, const Common::UString& to);
 	int countOccurances(Common::UString line, uint32 find);
 	void countComments(Common::UString line);
 
 	// Line filters
+	Common::UString fixXMLTag(Common::UString line);
+	Common::UString parseLine(Common::UString line);
 	Common::UString fixLine(Common::UString line);
 	Common::UString trim(Common::UString line);
 	Common::UString fixOpenQuotes(Common::UString line);
@@ -64,6 +64,7 @@ private:
 	Common::UString doubleDashFix(Common::UString line);
 	Common::UString tripleQuoteFix(Common::UString line);
 	Common::UString quotedCloseFix(Common::UString line);
+	Common::UString replaceText(Common::UString line, const Common::UString badStr, const Common::UString goodStr);
 	Common::UString escapeSpacedStrings(Common::UString line, bool undo);
 	Common::UString fixMismatchedParen(Common::UString line);
 	Common::UString fixCloseBraceQuote(Common::UString line);

--- a/src/aurora/xmlfix.h
+++ b/src/aurora/xmlfix.h
@@ -28,6 +28,8 @@
 #include <iostream>
 #include <string>
 
+#include "src/common/ustring.h"
+
 namespace Common {
 	class Ustring;
 	class SeekableReadStream;
@@ -38,21 +40,26 @@ namespace Aurora {
 class XMLFix { 
 
 public:
-	static Common::SeekableReadStream *fixXML(Common::SeekableReadStream *xml);
+	Common::SeekableReadStream *fixXMLStream(Common::SeekableReadStream *xml);
 
-	// Temporary public/static for testing because they're called from main()
+	// Temporarily public for testing because they're called from fix2xml
 	Common::UString fixXMLTag(Common::UString line);
 	Common::UString parseLine(Common::UString line);
 
 private:
+	int comCount = 0;        // Track number of open/closed comments
+	bool inUIButton = false; // Used to fix </UIButton> tags that were never opened
+
+	void replaceAll(Common::UString& str, const Common::UString& from, const Common::UString& to);
+	int countOccurances(Common::UString line, char find);
+	void countComments(Common::UString line);
+
+	// Line filters
 	Common::UString fixLine(Common::UString line);
 	Common::UString trim(Common::UString line);
 	Common::UString fixOpenQuotes(Common::UString line);
 	Common::UString escapeInnerQuotes(Common::UString line);
 	Common::UString replaceString(Common::UString& origStr, Common::UString& oldText, Common::UString newText);
-	void replaceAll(Common::UString& str, const Common::UString& from, const Common::UString& to);
-	int countOccurances(Common::UString line, char find);
-	void countComments(std::string line);
 	Common::UString fixCopyright(Common::UString line);
 	Common::UString doubleDashFix(Common::UString line);
 	Common::UString tripleQuoteFix(Common::UString line);
@@ -63,7 +70,6 @@ private:
 	Common::UString fixUnclosedQuote(Common::UString line);
 	Common::UString fixUnevenQuotes(Common::UString line);
 	Common::UString fixUnclosedNodes(Common::UString line);
-
 };
 
 } // End of namespace Aurora

--- a/src/aurora/xmlfix.h
+++ b/src/aurora/xmlfix.h
@@ -44,7 +44,6 @@ public:
 
 private:
 	int  comCount = 0;        	// Track the number of open/closed comments
-	bool fixedXML = false;   	// Track if xml tag is fixed
 	bool fixedCopyright = false;	// Track if the copyright character is fixed
 	bool inUIButton = false; 	// Used to fix </UIButton> tags that were never opened
 

--- a/src/aurora/xmlfix.h
+++ b/src/aurora/xmlfix.h
@@ -40,16 +40,17 @@ namespace Aurora {
 class XMLFix { 
 
 public:
-	Common::SeekableReadStream *fixXMLStream(Common::SeekableReadStream &xml);
+	Common::SeekableReadStream *fixXMLStream(Common::SeekableReadStream &xml, bool hideComments = false);
 
 private:
-	int  comCount = 0;        	// Track the number of open/closed comments
-	bool fixedCopyright = false;	// Track if the copyright character is fixed
-	bool inUIButton = false; 	// Used to fix </UIButton> tags that were never opened
+	int  _comCount = 0;        	// Track the number of open/closed comments
+	bool _hideComments = false;     // If true, blank out any comment lines
+	bool _fixedCopyright = false;	// Track if the copyright character is fixed
+	bool _inUIButton = false; 	// Used to fix </UIButton> tags that were never opened
 
 	void replaceAll(Common::UString& str, const Common::UString& from, const Common::UString& to);
 	int countOccurances(Common::UString line, uint32 find);
-	void countComments(Common::UString line);
+	bool isCommentLine(Common::UString line);
 
 	// Line filters
 	Common::UString fixXMLTag(Common::UString line);

--- a/src/aurora/xmlfix.h
+++ b/src/aurora/xmlfix.h
@@ -48,22 +48,16 @@ private:
 	bool _fixedCopyright = false;	// Track if the copyright character is fixed
 	bool _inUIButton = false; 	// Used to fix </UIButton> tags that were never opened
 
-	void replaceAll(Common::UString& str, const Common::UString& from, const Common::UString& to);
 	int countOccurances(Common::UString line, uint32 find);
 	bool isCommentLine(Common::UString line);
 
 	// Line filters
 	Common::UString fixXMLTag(Common::UString line);
 	Common::UString parseLine(Common::UString line);
-	Common::UString fixLine(Common::UString line);
-	Common::UString trim(Common::UString line);
 	Common::UString fixOpenQuotes(Common::UString line);
 	Common::UString escapeInnerQuotes(Common::UString line);
-	Common::UString replaceString(Common::UString& origStr, Common::UString& oldText, Common::UString newText);
 	Common::UString fixCopyright(Common::UString line);
 	Common::UString doubleDashFix(Common::UString line);
-	Common::UString tripleQuoteFix(Common::UString line);
-	Common::UString quotedCloseFix(Common::UString line);
 	Common::UString replaceText(Common::UString line, const Common::UString badStr, const Common::UString goodStr);
 	Common::UString escapeSpacedStrings(Common::UString line, bool undo);
 	Common::UString fixMismatchedParen(Common::UString line);

--- a/src/aurora/xmlfix.h
+++ b/src/aurora/xmlfix.h
@@ -44,6 +44,7 @@ public:
 
 private:
 	int  _comCount = 0;        	// Track the number of open/closed comments
+	bool _openTag = false;          // True if a non-comment tag has not been closed on current line
 	bool _hideComments = false;     // If true, blank out any comment lines
 	bool _fixedCopyright = false;	// Track if the copyright character is fixed
 	bool _inUIButton = false; 	// Used to fix </UIButton> tags that were never opened

--- a/src/aurora/xmlfix.h
+++ b/src/aurora/xmlfix.h
@@ -47,11 +47,11 @@ public:
 	Common::UString parseLine(Common::UString line);
 
 private:
-	int comCount = 0;        // Track number of open/closed comments
+	int comCount = 0;        // Track the number of open/closed comments
 	bool inUIButton = false; // Used to fix </UIButton> tags that were never opened
 
 	void replaceAll(Common::UString& str, const Common::UString& from, const Common::UString& to);
-	int countOccurances(Common::UString line, char find);
+	int countOccurances(Common::UString line, uint32 find);
 	void countComments(Common::UString line);
 
 	// Line filters

--- a/src/aurora/xmlfix.h
+++ b/src/aurora/xmlfix.h
@@ -63,11 +63,9 @@ private:
 	Common::UString fixUnevenQuotes(Common::UString line);
 	Common::UString fixUnclosedQuote(Common::UString line);
 	Common::UString fixCloseBraceQuote(Common::UString line);
-	Common::UString doubleDashFix(Common::UString line);
+	Common::UString commentFix(Common::UString line);
 	Common::UString replaceText(Common::UString line, const Common::UString badStr, const Common::UString goodStr);
 	Common::UString fixKnownIssues(Common::UString line);
-	Common::UString escapeSpacedStrings(Common::UString line);
-	Common::UString tokenizeProblemPhrases(Common::UString line, bool undo);
 };
 
 } // End of namespace Aurora

--- a/src/aurora/xmlfix.h
+++ b/src/aurora/xmlfix.h
@@ -53,19 +53,21 @@ private:
 	bool isCommentLine(Common::UString line);
 
 	// Line filters
-	Common::UString fixXMLTag(Common::UString line);
 	Common::UString parseLine(Common::UString line);
-	Common::UString fixOpenQuotes(Common::UString line);
-	Common::UString escapeInnerQuotes(Common::UString line);
 	Common::UString fixCopyright(Common::UString line);
+	Common::UString fixXMLTag(Common::UString line);
+	Common::UString fixUnclosedNodes(Common::UString line);
+	Common::UString escapeInnerQuotes(Common::UString line);
+	Common::UString fixMismatchedParen(Common::UString line);
+	Common::UString fixOpenQuotes(Common::UString line);
+	Common::UString fixUnevenQuotes(Common::UString line);
+	Common::UString fixUnclosedQuote(Common::UString line);
+	Common::UString fixCloseBraceQuote(Common::UString line);
 	Common::UString doubleDashFix(Common::UString line);
 	Common::UString replaceText(Common::UString line, const Common::UString badStr, const Common::UString goodStr);
-	Common::UString escapeSpacedStrings(Common::UString line, bool undo);
-	Common::UString fixMismatchedParen(Common::UString line);
-	Common::UString fixCloseBraceQuote(Common::UString line);
-	Common::UString fixUnclosedQuote(Common::UString line);
-	Common::UString fixUnevenQuotes(Common::UString line);
-	Common::UString fixUnclosedNodes(Common::UString line);
+	Common::UString fixKnownIssues(Common::UString line);
+	Common::UString escapeSpacedStrings(Common::UString line);
+	Common::UString tokenizeProblemPhrases(Common::UString line, bool undo);
 };
 
 } // End of namespace Aurora

--- a/src/common/ustring.cpp
+++ b/src/common/ustring.cpp
@@ -338,6 +338,13 @@ bool UString::contains(uint32 c) const {
 	return findFirst(c) != end();
 }
 
+uint32 UString::at(size_t pos) const {
+	if (pos < _size)
+		return _string.at(pos);
+	else
+		return 0;
+}
+
 void UString::truncate(const iterator &it) {
 	UString temp;
 

--- a/src/common/ustring.h
+++ b/src/common/ustring.h
@@ -200,7 +200,10 @@ public:
 	/** Replicate std::string functionality */
 	// For now this is test only -- I hope to merge as much as possible into xmlfix.cpp
 	uint32 at(size_t pos) {
-		return _string.at(pos);
+		if (pos < _size)
+			return _string.at(pos);
+		else
+			return 0;
 	}
 	void erase(size_t pos, size_t len) {
 		if (len < 1)

--- a/src/common/ustring.h
+++ b/src/common/ustring.h
@@ -197,6 +197,40 @@ public:
 
 	static uint32 fromUTF16(uint16 c);
 
+	/** Replicate std::string functionality */
+	// For now this is test only -- I hope to merge as much as possible into xmlfix.cpp
+	uint32 at(size_t pos) {
+		return _string.at(pos);
+	}
+	void erase(size_t pos, size_t len) {
+		if (len < 1)
+			return;
+		this->erase(this->getPosition(pos), this->getPosition(pos + len));
+	}
+	size_t find(const UString &str) {
+		return this->getPosition(this->findFirst(str));
+	}
+	size_t find_last_of(uint32 c) {
+		return this->getPosition(this->findLast(c));
+	}
+	size_t find_last_of(UString &str) {
+		uint32 c = str.at(0);
+		return this->find_last_of(c); // Temporary hack: just match first character
+	}
+	void insert(size_t pos, const UString &str) {
+		this->insert(this->getPosition(pos), str);
+	}
+	// length -> use size()
+	size_t length() {
+		return _size;
+	}
+	void replace(size_t pos, size_t len, const UString &str) {
+		if (len < 1)
+			return;
+		this->erase(this->getPosition(pos), this->getPosition(pos+len));
+		this->insert(this->getPosition(pos), str);
+	}
+
 private:
 	std::string _string; ///< Internal string holding the actual data.
 

--- a/src/common/ustring.h
+++ b/src/common/ustring.h
@@ -135,6 +135,9 @@ public:
 	bool contains(const UString &what) const;
 	bool contains(uint32 c) const;
 
+	/** Return the (utf8 encoded) character at the position index */
+	uint32 at(size_t pos) const;
+
 	void truncate(const iterator &it);
 	void truncate(size_t n);
 
@@ -196,43 +199,6 @@ public:
 	static bool isCntrl(uint32 c); ///< Is the character an ASCII control character?
 
 	static uint32 fromUTF16(uint16 c);
-
-	/** Replicate std::string functionality */
-	// For now this is test only -- I hope to merge as much as possible into xmlfix.cpp
-	uint32 at(size_t pos) {
-		if (pos < _size)
-			return _string.at(pos);
-		else
-			return 0;
-	}
-	void erase(size_t pos, size_t len) {
-		if (len < 1)
-			return;
-		this->erase(this->getPosition(pos), this->getPosition(pos + len));
-	}
-	size_t find(const UString &str) {
-		return this->getPosition(this->findFirst(str));
-	}
-	size_t find_last_of(uint32 c) {
-		return this->getPosition(this->findLast(c));
-	}
-	size_t find_last_of(UString &str) {
-		uint32 c = str.at(0);
-		return this->find_last_of(c); // Temporary hack: just match first character
-	}
-	void insert(size_t pos, const UString &str) {
-		this->insert(this->getPosition(pos), str);
-	}
-	// length -> use size()
-	size_t length() {
-		return _size;
-	}
-	void replace(size_t pos, size_t len, const UString &str) {
-		if (len < 1)
-			return;
-		this->erase(this->getPosition(pos), this->getPosition(pos+len));
-		this->insert(this->getPosition(pos), str);
-	}
 
 private:
 	std::string _string; ///< Internal string holding the actual data.

--- a/src/fix2xml.cpp
+++ b/src/fix2xml.cpp
@@ -1,0 +1,154 @@
+/* xoreos-tools - Tools to help with xoreos development
+ *
+ * xoreos-tools is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos-tools is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos-tools is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos-tools. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ * Command-line tool to fix broken, non-standard NWN2 XML files.
+ */
+
+/*
+ * TODO:
+ * Use XMLFix::fixXMLStream for XML corrections
+ * Remove need for 'trim' call
+ * Throw exceptions from file processing
+ * Pass output file path as an (optional) argument
+ * Use the common parser
+ * Standardize per project practices
+ */
+
+#include <iostream>
+#include <string>
+#include <fstream>
+#include <algorithm>
+#include <stdio.h>
+#include <ctype.h>
+#include "src/common/ustring.h"
+#include "src/aurora/xmlfix.h"
+// using namespace Aurora;
+
+using std::cout;
+using std::endl;
+using std::string;
+
+// Prototypes
+int fixXMLFile(Common::UString &inFile);
+std::string strim(std::string line);
+
+int main(int argc, char** argv) {
+	if (argc != 2) {
+		cout << "Please specify an xml file to parse.\n"
+			"a file name <fileName>Fixed will be created.\n";
+		return -1;
+	}
+
+	Common::UString inFile = argv[1];
+
+	int rCode = fixXMLFile( inFile );
+
+	return rCode;
+}
+
+/*
+ * Read in the input file, apply XML format corections, then write to output file.
+ */
+int fixXMLFile(Common::UString &inFile) {
+	// Get the i/o file names	
+	std::string oldFileName = inFile.c_str();
+	std::string newFileName = oldFileName;
+	std::string sline;    // Input line
+	Common::UString line; // Conversion line for XMLFix class call
+	Aurora::XMLFix fixer; // Need a copy of the XML filter class
+	
+	// Find location of period in the file name.
+	size_t perLoc = oldFileName.find(".");
+	if (perLoc != std::string::npos) {
+		// Found a period, so add 'Fixed' before the extension
+		newFileName.insert(perLoc, "Fixed");
+	} else {
+		// Add 'Fixed' at the end of the file
+		newFileName = newFileName + "Fixed";
+	}
+	
+	// Open the files
+	std::ifstream readFile(oldFileName, std::ios::in);
+	if (!readFile.is_open()) {
+		// We check twice so that we don't create files if garbage is passed in.
+		cout << "Error opening files." << endl;
+		return -1;
+	}
+	std::ofstream writeFile(newFileName, std::ios::out | std::ios::trunc); // Create or overwrite
+	if (!writeFile.is_open()) {
+		cout << "Error opening files." << endl;
+		return -1;
+	}
+	
+	// Read in the first line
+	if (std::getline(readFile, sline)) {
+		// Convert to UString for XMLFix class function call
+		line = sline;
+
+		// Check for XML format
+		if (strim(sline).find("<?xml") == 0) {
+			// Filter the line then write to file
+			line = fixer.fixXMLTag(line);
+			writeFile << line.c_str() << "\n";
+		} else {
+			// Abort
+			cout << "Improper XML file.\n";
+			return -1;
+		}
+	} else {
+		// Abort
+		cout << "Error reading file\n";
+		return -1;
+	}
+
+	// Insert the root element.
+	writeFile << "<Root>\n";
+	while (std::getline(readFile, sline)) {
+		// Convert to UString for class function call
+		line = sline;
+		line = fixer.parseLine(line);
+		writeFile << line.c_str() << "\n";
+	}
+	writeFile << "</Root>\n";
+	
+	// Close the files
+	readFile.close();
+	writeFile.close();
+	return 0;
+}
+
+
+// Temporarily copied from xmlfix.cpp
+/**
+* Remove leading and trailing whitespace.
+* Returns line without leading and trailing
+* Spaces.
+*/
+std::string strim(std::string line) {
+	string whitespace = " \t\n\v\f\r";
+	size_t lineBegin = line.find_first_not_of(whitespace);
+	if (lineBegin == std::string::npos) {
+		return ""; // empty string
+	}
+	int lineEnd = line.find_last_not_of(whitespace);
+	int lineRange = lineEnd - lineBegin + 1;
+	return line.substr(lineBegin, lineRange);
+}

--- a/src/fix2xml.cpp
+++ b/src/fix2xml.cpp
@@ -41,16 +41,13 @@
 #include "src/common/memreadstream.h"
 #include "src/aurora/xmlfix.h"
 
-const Common::UString OUTPUT_FILE_TAG = "_Fixed"; // Add tag if no output file specified
+const Common::UString OUTPUT_FILE_TAG = "_Fixed"; // Tag to add if no output file specified
 
-// Prototypes
 bool parseCommandLine(const std::vector<Common::UString> &argv, int &returnValue,
                       Common::UString &inFile, Common::UString &outFile);
 
 void convert(Common::UString &inFile, Common::UString &outFile);
-void old_convert(const Common::UString &inFile, const Common::UString &outFile);
 
-std::string strim(std::string line);
 
 int main(int argc, char **argv) {
 	initPlatform();
@@ -99,8 +96,8 @@ void convert(Common::UString &inFile, Common::UString &outFile) {
 		outFileName = inFile;
 
 		// Find location of period in the file name.
-		size_t perLoc = inFile.find(".");
-		if (perLoc != std::string::npos) {
+		Common::UString::iterator perLoc = outFileName.findLast('.');
+		if (perLoc != outFileName.end()) {
 			// Found a period, so insert tag before the extension
 			outFileName.insert(perLoc, OUTPUT_FILE_TAG);
 		} else {

--- a/src/rules.mk
+++ b/src/rules.mk
@@ -310,6 +310,18 @@ src_erf_LDADD = \
     $(LDADD) \
     $(EMPTY)
 
+bin_PROGRAMS += src/fix2xml
+src_fix2xml_SOURCES = \
+    src/fix2xml.cpp \
+    src/util.cpp \
+    $(EMPTY)
+src_fix2xml_LDADD = \
+    src/aurora/libaurora.la \
+    src/common/libcommon.la \
+    src/version/libversion.la \
+    $(LDADD) \
+    $(EMPTY)
+
 # Subdirectories
 
 include src/version/rules.mk

--- a/tests/aurora/rules.mk
+++ b/tests/aurora/rules.mk
@@ -115,3 +115,9 @@ check_PROGRAMS                      += tests/aurora/test_erfwriter
 tests_aurora_test_erfwriter_SOURCES  = tests/aurora/erfwriter.cpp
 tests_aurora_test_erfwriter_LDADD    = $(aurora_LIBS)
 tests_aurora_test_erfwriter_CXXFLAGS = $(test_CXXFLAGS)
+
+check_PROGRAMS                      += tests/aurora/test_xmlfix
+tests_aurora_test_xmlfix_SOURCES     = tests/aurora/xmlfix.cpp
+tests_aurora_test_xmlfix_LDADD       = $(aurora_LIBS)
+tests_aurora_test_xmlfix_CXXFLAGS    = $(test_CXXFLAGS)
+

--- a/tests/aurora/xmlfix.cpp
+++ b/tests/aurora/xmlfix.cpp
@@ -105,34 +105,9 @@ GTEST_TEST(xmlFix, fixXMLStream) {
 
 	Aurora::XMLFix converter;
 	Common::SeekableReadStream *valid = converter.fixXMLStream(*invalid);
-//	int kDataValidSize = strlen(kDataValid) + 28; // Add the '\' escape characters
-//	ASSERT_EQ(valid->size(), kDataValid);
 	ASSERT_EQ(valid->size(), strlen(kDataValid));
 
-//	bool isEscape false;
 	for (size_t i = 0; i < strlen(kDataValid); i++) {
-		// Convert escaped characters
-//		char cDataValid = kDataValid[i];
-//		if (kDataValid[i] == '\"') {
-//			// Skip to the escaped character
-//			isEscape = true;
-//			continue;
-//		} else if (isEscape) {
-//			// Convert to the escaped character
-//			switch (c) {
-//				't':
-//					c = '\t';
-//					break;
-//				'n':
-//					c = '\n';
-//					break;
-//			}
-//
-//			// Escape complete
-//			isEscape = false;
-//		}
-
-//		EXPECT_EQ(valid->readByte(), cDataValid) << "At index " << i;
 		EXPECT_EQ(valid->readByte(), kDataValid[i]) << "At index " << i;
 	}
 

--- a/tests/aurora/xmlfix.cpp
+++ b/tests/aurora/xmlfix.cpp
@@ -1,0 +1,142 @@
+/* xoreos-tools - Tools to help with xoreos development
+ *
+ * xoreos-tools is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos-tools is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos-tools is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos-tools. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Unit test for the NWN2 XML validation fix
+ */
+
+#include "gtest/gtest.h"
+
+#include "src/common/util.h"
+#include "src/common/error.h"
+#include "src/common/memreadstream.h"
+
+#include "src/aurora/xmlfix.h"
+
+// Invalid NWN2 XML 
+static const char *kDataInvalid =
+	"abc<?xml version=\"1.0\" encoding=\"NWN2UI\">\n"
+	"<!-- Copyright 2006 Obsidian Entertainment, Inc. -->\n"
+	"\n"
+	"\t<!--\n"
+	"\t\t-- double dash\n"
+	"\t-->\n"
+	"\n"
+	"<UIScene name=\"FOOBAR\" fadeout=\"0.3\" fadein=\"0.3\" x=0 y=0 fullscreen=true\n"
+	"\t width=SCREEN_WIDTH height=SCREEN_HEIGHT\n"
+	"\t OnAdd=UIScene_OnAdd_SetUpServerOptions( \n"
+	"\t OnRemove=UIScene_OnRemove_SaveServerOptions()\n"
+	"\t priority=\"SCENE_FE_FULLSCREEN\" \n"
+	"\t /> <!-- Appended comment -->\n"
+	"\n"
+	"\t\t<UIText name=\"IDENTIFY_TEXT\" width=PARENT_WIDTH height=PARENT_HEIGHT align=center valign=middle uppercase=truefontfamily=\"Default\" style=\"bold\" />\n"
+	"\n"
+	"\t<UIText name=\"PreHorizonB\" strref=\"181357\"\" x=5 y=368 width=90\" height=16 valign=\"middle align=LEFT fontfamily=\"Special_Font\" style=\"1\"  />\n"
+	"\n"
+	"\t</UIButton>\n"
+	"\t<UIButton name=\"CAMERA_ZOOM_OUT\" x=\"0\" y=\"0\" width=\"35\" height=\"34\" buttontype=\"radio\" groupid=\"2\" groupmemberid=\"1\" DefaultToolTip=\"181294\"\n"
+	"\t\t\tOnSelected=UIButton_Input_Move3DCamera(\"TEMP_CHARACTER_SCENE\",\"PLAYER_CREATURE\",\"SET_POSITION\",\"-1.25\",\"0.0\",\"1.3\",\"-0.90\",\"4.0\",\"1.1\",\"0.5\")\n"
+	"\t\t\tOnToolTip=UIObject_Tooltip_DisplayObject(OBJECT_X,OBJECT_Y,SCREEN_TOOLTIP_2,ALIGN_NONE,ALIGN_NONE,0,0,ALIGN_LEFT\") >\n"
+	"\n"
+	"<!--\n"
+	"(W) for ‘whisper’\n"
+	"-->\n"
+	"\n"
+	"</UIButton>\n"
+	"<UIButton name=\"LOCAL SAY\" buttontype=radio groupid=1 groupmemberid=1 \n"
+	"\tOnSelected=UIButton_Input_SetChatMode(0) style=\"CHAT_MODE_BUTTON\"    text=\"L\"\n"
+	"\tOnToolTip=UIObject_Tooltip_DisplayTooltipStringRef(184736,\"OBJECT_X\",\"OBJECT_Y\",\"SCREEN_TOOLTIP_2\") />\n"
+	"\n"
+	"\t<UIButton name=\"DUNGEON MASTER\" buttontype=\"radio\" groupid=\"1\" groupmemberid=\"4\" \n"
+	"\t\tOnSelected=UIButton_Input_SetChatMode(3) style=\"CHAT_MODE_BUTTON\"  text=\"D\"\n"
+	"\t\tOnToolTip=UIObject_Tooltip_DisplayTooltipStringRef(184739,\"OBJECT_X\",OBJECT_Y,\"SCREEN_TOOLTIP_2\") />\n"
+	"\n";
+
+// Valid XML
+static const char *kDataValid =
+	"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+	"<Root>\n"
+	"<!-- Copyright &copy; 2006 Obsidian Entertainment, Inc. -->\n"
+	"\n"
+	"\t<!--\n"
+	"\t\t- double dash\n"
+	"\t-->\n"
+	"\n"
+	"<UIScene name=\"FOOBAR\" fadeout=\"0.3\" fadein=\"0.3\" x=\"0\" y=\"0\" fullscreen=\"true\" width=\"SCREEN_WIDTH\" height=\"SCREEN_HEIGHT\" OnAdd=\"UIScene_OnAdd_SetUpServerOptions(\" OnRemove=\"UIScene_OnRemove_SaveServerOptions()\" priority=\"SCENE_FE_FULLSCREEN\" /> <!-- Appended comment -->\n"
+	"\n"
+	"\t\t<UIText name=\"IDENTIFY_TEXT\" width=\"PARENT_WIDTH\" height=\"PARENT_HEIGHT\" align=\"center\" valign=\"middle\" uppercase=\"true\" fontFamily=\"Default\" style=\"bold\" />\n"
+	"\n"
+	"\t<UIText name=\"PreHorizonB\" strref=\"181357\" x=\"5\" y=\"368\" width=\"90\" height=\"16\" valign=\"middle\" align=\"LEFT\" fontfamily=\"Special_Font\" style=\"1\"  />\n"
+	"\n"
+	"\t\n"
+	"\t<UIButton name=\"CAMERA_ZOOM_OUT\" x=\"0\" y=\"0\" width=\"35\" height=\"34\" buttontype=\"radio\" groupid=\"2\" groupmemberid=\"1\" DefaultToolTip=\"181294\" OnSelected=\"UIButton_Input_Move3DCamera(&quot;TEMP_CHARACTER_SCENE&quot;,&quot;PLAYER_CREATURE&quot;,&quot;SET_POSITION&quot;,&quot;-1.25&quot;,&quot;0.0&quot;,&quot;1.3&quot;,&quot;-0.90&quot;,&quot;4.0&quot;,&quot;1.1&quot;,&quot;0.5&quot;)\" OnToolTip=\"UIObject_Tooltip_DisplayObject(&quot;OBJECT_X&quot;,&quot;OBJECT_Y&quot;,&quot;SCREEN_TOOLTIP_2&quot;,&quot;ALIGN_NONE&quot;,&quot;ALIGN_NONE&quot;,&quot;0&quot;,&quot;0&quot;,&quot;ALIGN_LEFT&quot;)\" >\n"
+	"\n"
+	"<!--\n"
+	"(W) for whisper\n"
+	"-->\n"
+	"\n"
+	"</UIButton>\n"
+	"<UIButton name=\"LOCAL&#32;SAY\" buttontype=\"radio\" groupid=\"1\" groupmemberid=\"1\" OnSelected=\"UIButton_Input_SetChatMode(&quot;0&quot;)\" style=\"CHAT_MODE_BUTTON\"    text=\"L\" OnToolTip=\"UIObject_Tooltip_DisplayTooltipStringRef(&quot;184736&quot;,&quot;OBJECT_X&quot;,&quot;OBJECT_Y&quot;,&quot;SCREEN_TOOLTIP_2&quot;)\" />\n"
+	"\n"
+	"\t<UIButton name=\"DUNGEON&#32;MASTER\" buttontype=\"radio\" groupid=\"1\" groupmemberid=\"4\" OnSelected=\"UIButton_Input_SetChatMode(&quot;3&quot;)\" style=\"CHAT_MODE_BUTTON\"  text=\"D\" OnToolTip=\"UIObject_Tooltip_DisplayTooltipStringRef(&quot;184739&quot;,&quot;OBJECT_X&quot;,&quot;OBJECT_Y&quot;,&quot;SCREEN_TOOLTIP_2&quot;)\" />\n"
+	"\n"
+	"\n"
+	"</Root>\n";
+
+GTEST_TEST(xmlFix, fixXMLStream) {
+	Common::SeekableReadStream *invalid = new Common::MemoryReadStream(kDataInvalid);
+
+	Aurora::XMLFix converter;
+	Common::SeekableReadStream *valid = converter.fixXMLStream(*invalid);
+//	int kDataValidSize = strlen(kDataValid) + 28; // Add the '\' escape characters
+//	ASSERT_EQ(valid->size(), kDataValid);
+	ASSERT_EQ(valid->size(), strlen(kDataValid));
+
+//	bool isEscape false;
+	for (size_t i = 0; i < strlen(kDataValid); i++) {
+		// Convert escaped characters
+//		char cDataValid = kDataValid[i];
+//		if (kDataValid[i] == '\"') {
+//			// Skip to the escaped character
+//			isEscape = true;
+//			continue;
+//		} else if (isEscape) {
+//			// Convert to the escaped character
+//			switch (c) {
+//				't':
+//					c = '\t';
+//					break;
+//				'n':
+//					c = '\n';
+//					break;
+//			}
+//
+//			// Escape complete
+//			isEscape = false;
+//		}
+
+//		EXPECT_EQ(valid->readByte(), cDataValid) << "At index " << i;
+		EXPECT_EQ(valid->readByte(), kDataValid[i]) << "At index " << i;
+	}
+
+	delete invalid;
+	delete valid;
+}
+

--- a/tests/common/ustring.cpp
+++ b/tests/common/ustring.cpp
@@ -296,6 +296,22 @@ GTEST_TEST(UString, containsString) {
 	EXPECT_FALSE(str.contains("Qux"));
 }
 
+GTEST_TEST(UString, at) {
+	const Common::UString str("Foobar Barfoo");
+
+	uint32 f = str.at(0);
+	uint32 b = str.at(7);
+	uint32 r = str.at(9);
+	uint32 o = str.at(12);
+	uint32 e = str.at(13);
+
+	EXPECT_EQ(f, 'F');
+	EXPECT_EQ(b, 'B');
+	EXPECT_EQ(r, 'r');
+	EXPECT_EQ(o, 'o');
+	EXPECT_EQ(e, 0);
+}
+
 GTEST_TEST(UString, truncateInt) {
 	Common::UString str("Foobar Barfoo");
 


### PR DESCRIPTION
The XMLFix class accepts a SeekableReadStream containing the contents of a
NWN2 XML file and return a SeekableReadStream with a valid XML output.

This class is verified by means of the included fix2xml command-line tool, which
converts a NWN2 XML file to a valid XML file. The stock XML files, as well as XMLs
from three mod packages, when run through this tool and the converted files
validated using 'xmllint', report no format warnings. The test mod packages are
as follows:

- Tchos' HD UI panels and dialogue compilation and expansion
- SlimGUI - Black UI
- Kaldor Silverwand Context Menu Additions

To implement this functionality, an at() call is inserted into the Common::UString
class and isSpace() is modified to work with any space character. Unit tests are
added for XMLFix and UString.