### PR TITLE
NWN2: Library and tool to fix NWN2 XML files

### DIFF
--- a/man/fixnwn2xml.1
+++ b/man/fixnwn2xml.1
@@ -1,0 +1,52 @@
+.Dd September 27, 2018
+.Dt FIXNWN2XML 1
+.Os
+.Sh NAME
+.Nm fixnwn2xml
+.Nd Convert Obsidian NWN2 XML to valid XML
+.Sh SYNOPSIS
+.Nm fixnwn2xml
+.Op Ar options
+.Ar input_file
+.Op Ar output_file
+.Sh DESCRIPTION
+.Nm
+converts Obsidian's XML files for Neverwinter Nights 2 into
+validated XML that conforms to W3C specifications for XML 1.0.
+Any indentation and comments in the input file will be removed.
+.Sh OPTIONS
+.Bl -tag -width xxxx -compact
+.It Fl h
+.It Fl Fl help
+Show a help text and exit.
+.It Fl Fl version
+Show version information and exit.
+.El
+.Bl -tag -width xxxx -compact
+.It Ar input_file
+The XML file to convert.
+.It Op Ar output_file
+The converted XML data will be written there.
+If no output file is specified, the converted XML data is
+written to standard output.
+The encoding of the XML output is always UTF-8.
+.El
+.Sh EXAMPLES
+Convert the NWN2 XML
+.Pa file1.xml
+into a valid XML file:
+.Pp
+.Dl $ fixnwn2xml file1.xml file2.xml
+.Pp
+.Sh SEE ALSO
+.Xr tlk2xml 1 ,
+.Xr ssf2xml 1
+.Pp
+More information about the xoreos project can be found on
+.Lk https://xoreos.org/ "its website" .
+.Sh AUTHORS
+This program is part of the xoreos-tools package, which in turn is
+part of the xoreos project, and was written by the xoreos team.
+Please see the
+.Pa AUTHORS
+file for details.

--- a/src/aurora/rules.mk
+++ b/src/aurora/rules.mk
@@ -55,6 +55,7 @@ src_aurora_libaurora_la_SOURCES += \
     src/aurora/nsbtxfile.h \
     src/aurora/erfwriter.h \
     src/aurora/sacfile.h \
+    src/aurora/xmlfixer.h \
     $(EMPTY)
 
 src_aurora_libaurora_la_SOURCES += \
@@ -86,4 +87,5 @@ src_aurora_libaurora_la_SOURCES += \
     src/aurora/nsbtxfile.cpp \
     src/aurora/erfwriter.cpp \
     src/aurora/sacfile.cpp \
+    src/aurora/xmlfixer.cpp \
     $(EMPTY)

--- a/src/aurora/xmlfixer.cpp
+++ b/src/aurora/xmlfixer.cpp
@@ -49,6 +49,7 @@ namespace Aurora {
 Common::SeekableReadStream *XMLFixer::fixXMLStream(Common::SeekableReadStream &in) {
 	Common::MemoryWriteStreamDynamic out(true, in.size());
 	XMLFixer fixer;
+	Common::UString line;
 
 	try {
 		ElementList elements;
@@ -67,7 +68,13 @@ Common::SeekableReadStream *XMLFixer::fixXMLStream(Common::SeekableReadStream &i
 		out.writeString("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n");
 		out.writeString("<Root>\n");
 
-		// Write the footer
+		// Fix each element and write to the output stream
+		for (ElementList::iterator it = elements.begin(); it != elements.end(); ++it) {
+			line = fixer.fixXMLElement(*it) + '\n';
+			out.writeString(line);
+		}
+
+		// Close the root element
 		out.writeString("</Root>\n");
 
 	} catch (Common::Exception &e) {
@@ -78,6 +85,15 @@ Common::SeekableReadStream *XMLFixer::fixXMLStream(Common::SeekableReadStream &i
 	// Return the converted stream
 	out.setDisposable(false);
 	return new Common::MemoryReadStream(out.getData(), out.size(), true);
+}
+
+/**
+ * Bring the element into a valid XML form
+ */
+Common::UString XMLFixer::fixXMLElement(Common::UString element) {
+	Common::UString line = element;
+
+	return line;
 }
 
 /**

--- a/src/aurora/xmlfixer.cpp
+++ b/src/aurora/xmlfixer.cpp
@@ -141,9 +141,35 @@ Common::UString XMLFixer::fixXMLElement(const Common::UString element) {
  * Fix the value to be valid XML
  */
 Common::UString XMLFixer::fixXMLValue(const Common::UString value) {
-	Common::UString line = value;
+	Common::UString line, tag;
+	Common::UString::iterator it1;
+	uint32 c;
 
-	return line;
+	// Initialization
+	line = value;
+	tag = ""; // For a closing tag
+
+	// Strip quotes from the ends
+	size_t n = line.size();
+	if (n > 0) {
+		c = line.at(n - 1);
+		if (c == '\"') {
+			it1 = line.getPosition(n - 1);
+			line.erase(it1);
+		}
+
+		if (line.size() > 0) {
+			c = line.at(0);
+			if (c == '\"') {
+				it1 = line.getPosition(0);
+				line.erase(it1);
+			}
+		}
+
+	}
+
+	// Add quotes back to both ends
+	return "\"" + line + "\"" + tag;
 }
 
 /**

--- a/src/aurora/xmlfixer.cpp
+++ b/src/aurora/xmlfixer.cpp
@@ -91,7 +91,7 @@ Common::SeekableReadStream *XMLFixer::fixXMLStream(Common::SeekableReadStream &i
  * Bring the element into a valid XML form
  */
 Common::UString XMLFixer::fixXMLElement(const Common::UString element) {
-	Common::UString line;
+	Common::UString line, name, value;
 	SegmentList segments;
 
 	// Split on the equals sign
@@ -105,16 +105,43 @@ Common::UString XMLFixer::fixXMLElement(const Common::UString element) {
 
 	// Cycle through the segments
 	line = "";
-	for (SegmentList::iterator it = segments.begin(); it != segments.end(); ++it) {
-		// Parse each segment for the last space character
+	for (SegmentList::iterator it1 = segments.begin(); it1 != segments.end(); ++it1) {
+		// Find the last space character
+		Common::UString::iterator it2 = it1->findLast(' ');
+		name = it1->substr(it2, it1->end());
+		value = it1->substr(it1->begin(), it2);
+
+		// Trim both parts
+		name.trim();
+		value.trim();
+
+		// Reassemble the line
 		if (line.size() == 0) {
-			// First segment should be the element type
-			line = *it;
+			// First segment should have the element type
+			if (value.size() > 0)
+				line = value + " " + name;
+			else
+				line = name;
 		} else {
+			// Fix the value segment
+			value = fixXMLValue(value);
+
 			// Subsequent segment
-			line += "=" + *it;
+			if (name.size() > 0)
+				line += "=" + value + " " + name;
+			else
+				line += "=" + value;
 		}
 	}
+
+	return line;
+}
+
+/*
+ * Fix the value to be valid XML
+ */
+Common::UString XMLFixer::fixXMLValue(const Common::UString value) {
+	Common::UString line = value;
 
 	return line;
 }

--- a/src/aurora/xmlfixer.cpp
+++ b/src/aurora/xmlfixer.cpp
@@ -158,6 +158,10 @@ Common::UString XMLFixer::fixXMLValue(const Common::UString value) {
 	// Strip quotes from the ends
 	line = stripEndQuotes(line);
 
+	// Handle special cases
+	if (line.size() > 0 && isFixSpecialCase(&line))
+		return line;
+
 	// Extract a closing tag
 	n = line.size();
 	if (n > 0) {
@@ -182,10 +186,6 @@ Common::UString XMLFixer::fixXMLValue(const Common::UString value) {
 
 	// Bypass if line is empty
 	if (line.size() > 0) {
-		// Handle unique issues
-		if (isFixSpecialCase(&line))
-			return line;
-
 		// Check for a new element start in this value
 		splitNewElement(&line, &tail);
 
@@ -318,12 +318,14 @@ Common::UString XMLFixer::fixParams(const Common::UString params) {
  */
 bool XMLFixer::isFixSpecialCase(Common::UString *value) {
 	bool isFix = false;
-	const int rows = 2;
+	const int rows = 4;
 	const Common::UString swap[rows][2] = {
 		{ "truefontfamily",
 		  "\"true\" fontfamily" },	// examine.xml
 		{ "Character\"fontfamily",
 		  "\"Character\" fontfamily" },	// multiplayer_downloadx2.xml
+		{ "->", "\"-&#62;\"" },		// gamespydetails.xml
+		{ ">>", "\"&#62;&#62;\"" },	// internetbrowser.xml
 	};
 
 	// Loop through the array

--- a/src/aurora/xmlfixer.cpp
+++ b/src/aurora/xmlfixer.cpp
@@ -177,6 +177,11 @@ Common::UString XMLFixer::fixXMLValue(const Common::UString value) {
 
 	// Bypass if line is empty
 	if (line.size() > 0) {
+		// Handle unique issues
+		if (isFixSpecialCase(&line))
+			return line;
+
+		// Check for a function
 		it = line.findFirst('(');
 		if (it != line.end())
 			line = fixFunction(line, it);
@@ -187,9 +192,38 @@ Common::UString XMLFixer::fixXMLValue(const Common::UString value) {
 }
 
 /**
+ * Address special issues found in specific NWN2 XML files
+ * by looking for exact matches to the problematic value
+ * strings then correcting the value on a match.
+ */
+bool XMLFixer::isFixSpecialCase(Common::UString *value) {
+	bool isFix = false;
+	const int rows = 2;
+	const Common::UString swap[rows][2] = {
+		{ "truefontfamily",
+		  "\"true\" fontfamily" },	// examine.xml
+		{ "Character\"fontfamily",
+		  "\"Character\" fontfamily" },	// multiplayer_downloadx2.xml
+	};
+
+	// Loop through the array
+	for (int i = 0; i < rows; i++) {
+		if (*value == swap[i][0]) {
+			// The strings match, so swap in the correction
+			*value = swap[i][1];
+			isFix = true;
+			break;
+		}
+	}
+
+	return isFix;
+}
+
+/**
  * Fix a function call
  */
-Common::UString XMLFixer::fixFunction(const Common::UString line, const Common::UString::iterator it) {
+Common::UString XMLFixer::fixFunction(const Common::UString value, const Common::UString::iterator it) {
+	Common::UString line = value;
 	return line; // TODO
 }
 

--- a/src/aurora/xmlfixer.cpp
+++ b/src/aurora/xmlfixer.cpp
@@ -1,0 +1,59 @@
+/* xoreos-tools - Tools to help with xoreos development
+ *
+ * xoreos-tools is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos-tools is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos-tools is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos-tools. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Fix broken, non-standard NWN2 XML files.
+ */
+
+#include <iostream>
+#include <string>
+#include <fstream>
+#include <algorithm>
+#include <stdio.h>
+#include <ctype.h>
+
+#include "src/common/memreadstream.h"
+#include "src/common/memwritestream.h"
+#include "src/common/error.h"
+#include "src/common/util.h"
+#include "src/aurora/xmlfixer.h"
+
+namespace Aurora {
+
+/**
+ * This filter converts the contents of an NWN2 XML data stream 'in'
+ * into standardized XML and returned the result as a new data stream.
+ */
+Common::SeekableReadStream *XMLFixer::fixXMLStream(Common::SeekableReadStream &in) {
+	Common::MemoryWriteStreamDynamic out(true, in.size());
+
+	try {
+	} catch (Common::Exception &e) {
+		e.add("Failed to fix XML stream");
+		throw e;
+	}
+
+	// Return the converted stream
+	out.setDisposable(false);
+	return new Common::MemoryReadStream(out.getData(), out.size(), true);
+}
+
+}
+

--- a/src/aurora/xmlfixer.cpp
+++ b/src/aurora/xmlfixer.cpp
@@ -48,13 +48,24 @@ namespace Aurora {
  */
 Common::SeekableReadStream *XMLFixer::fixXMLStream(Common::SeekableReadStream &in) {
 	Common::MemoryWriteStreamDynamic out(true, in.size());
+	Common::UString line, header;
 	XMLFixer fixer;
 
 	try {
 		ElementList elements;
 
-		// Read in the input stream
+		// Set to the stream start
+		in.seek(0);
+
+		// Read in the header
+		header = fixer.readXMLHeader(in);
+
+		// Convert input stream to a list of elements
 		fixer.readXMLStream(in, &elements);
+
+		// Fix the header and write to output
+		line = fixer.fixXMLHeader(header) + '\n';
+		out.write(line.c_str(), line.size());
 
 	} catch (Common::Exception &e) {
 		e.add("Failed to fix XML stream");
@@ -77,9 +88,6 @@ void XMLFixer::readXMLStream(Common::SeekableReadStream &in, ElementList *elemen
 	bool openTag = false;
 	bool priorTag  = false;
 	bool inComment = false;
-
-	// Read in the header
-	readXMLHeader(in);
 
 	// Cycle through the remaining input stream
 	while (!in.eos()) {
@@ -168,12 +176,8 @@ void XMLFixer::readXMLStream(Common::SeekableReadStream &in, ElementList *elemen
 /**
  * Read in the header and check the format.
  */
-void XMLFixer::readXMLHeader(Common::SeekableReadStream &in) {
+Common::UString XMLFixer::readXMLHeader(Common::SeekableReadStream &in) {
 	Common::UString line;
-	Common::UString header;
-
-	// Set to the stream start
-	in.seek(0);
 
 	// Loop until a non-blank line is found
 	do {
@@ -189,8 +193,15 @@ void XMLFixer::readXMLHeader(Common::SeekableReadStream &in) {
 	if (it == line.end())
 		throw Common::Exception("Input stream does not have an XML header");
 
-	// Extract header string
-	header = line.substr(it, line.end());
+	// Return the header string segment
+	return line.substr(it, line.end());
+}
+
+/**
+ * Convert the XML header into standard format
+ */
+Common::UString XMLFixer::fixXMLHeader(Common::UString header) {
+	return header; // TODO
 }
 
 /**

--- a/src/aurora/xmlfixer.cpp
+++ b/src/aurora/xmlfixer.cpp
@@ -91,17 +91,15 @@ Common::SeekableReadStream *XMLFixer::fixXMLStream(Common::SeekableReadStream &i
  * Bring the element into a valid XML form
  */
 Common::UString XMLFixer::fixXMLElement(const Common::UString element) {
-	Common::UString line;
+	Common::UString line = element;
 	SegmentList segments;
 
 	// Split on the equals sign
-	line.split(element, (uint32)'=', segments);
+	line.split(line, (uint32)'=', segments);
 
 	// If there is only one segment, just return it
-	if (segments.size() < 2) {
-		line = element;
+	if (segments.size() < 2)
 		return line;
-	}
 
 	// Cycle through the segments
 	line = "";
@@ -142,7 +140,6 @@ Common::UString XMLFixer::fixXMLElement(const Common::UString element) {
 				line += "=" + value;
 		}
 	}
-
 	return line;
 }
 
@@ -394,7 +391,7 @@ void XMLFixer::readXMLStream(Common::SeekableReadStream &in, ElementList *elemen
 			}
 
 			// Only append if line has text
-			if (line.size() != 0) {
+			if (line.size() > 0) {
 				// Append to the list
 				elements->push_back(line);
 			}
@@ -443,7 +440,7 @@ bool XMLFixer::isTagClose(const Common::UString value) {
 
 	// Search for a close tag
 	it1 = line.findLast('>');
-	if (it1 == line.begin())
+	if (it1 == line.end())
 		return false;
 
 	// Search backwards for an equals, quote, or comma

--- a/src/aurora/xmlfixer.cpp
+++ b/src/aurora/xmlfixer.cpp
@@ -391,8 +391,7 @@ Common::UString XMLFixer::fixParams(const Common::UString params) {
  */
 bool XMLFixer::isFixSpecialCase(Common::UString *value) {
 	bool isFix = false;
-	const int rows = 4;
-	const Common::UString swap[rows][2] = {
+	const Common::UString swap[4][2] = {
 		{ "truefontfamily",
 		  "\"true\" fontfamily" },	// examine.xml
 		{ "Character\"fontfamily",
@@ -400,6 +399,7 @@ bool XMLFixer::isFixSpecialCase(Common::UString *value) {
 		{ "->", "\"-&#62;\"" },		// gamespydetails.xml
 		{ ">>", "\"&#62;&#62;\"" },	// internetbrowser.xml
 	};
+	int rows = ARRAYSIZE(swap);
 
 	// Loop through the array
 	for (int i = 0; i < rows; i++) {

--- a/src/aurora/xmlfixer.cpp
+++ b/src/aurora/xmlfixer.cpp
@@ -49,7 +49,7 @@ namespace Aurora {
 Common::SeekableReadStream *XMLFixer::fixXMLStream(Common::SeekableReadStream &in) {
 	Common::MemoryWriteStreamDynamic out(true, in.size());
 	XMLFixer fixer;
-	
+
 	try {
 		// Read in the input stream
 		fixer.readXMLStream(in);
@@ -68,8 +68,56 @@ Common::SeekableReadStream *XMLFixer::fixXMLStream(Common::SeekableReadStream &i
  * Convert the input stream to a vector of elements.
  */
 void XMLFixer::readXMLStream(Common::SeekableReadStream &in) {
+	Common::UString::iterator it;
+	Common::UString line, buffer;
+	bool openTag = false;
+	bool priorTag  = false;
+
 	// Read in the header
 	readXMLHeader(in);
+
+	// Cycle through the remaining input stream
+	while (!in.eos()) {
+		// Track the previous state
+		priorTag = openTag;
+
+		// Read a line of text
+		line = Common::readStringLine(in, encoding);
+		line.trim(); // Trim now for maximum performance benefit
+
+		// Check for an end tag
+		openTag = !isTagClose(line);
+
+		/*
+		 * If current element is still open, add line to buffer.
+		 * Otherwise, add completed element to the vectors.
+		 */
+		if (openTag) {
+			// This is a multi-line wrap
+			if (!priorTag) {
+				// Starting a new buffer
+				buffer = line;
+			} else if (line.size() > 0) {
+				// Append line to the buffer with a space
+				buffer += " " + line;
+			}
+		} else {
+			// Check for a multi-line wrap
+			if (buffer.size() > 0) {
+				// Finish wrapping the lines
+				line = buffer + " " + line;
+				buffer = "";
+			}
+
+			// Only append if line has text
+			if (line.size() != 0) {
+				// Append to the vector
+			}
+
+			// Initialize for the next line
+			priorTag = false;
+		}
+	}
 }
 
 /**
@@ -98,6 +146,13 @@ void XMLFixer::readXMLHeader(Common::SeekableReadStream &in) {
 
 	// Extract header string
 	header = line.substr(it, line.end());
+}
+
+/**
+ * Return true if the line ends with a closing tag
+ */
+bool XMLFixer::isTagClose(Common::UString line) {
+	return true; // TODO
 }
 
 } // End of namespace AURORA

--- a/src/aurora/xmlfixer.cpp
+++ b/src/aurora/xmlfixer.cpp
@@ -68,7 +68,7 @@ Common::SeekableReadStream *XMLFixer::fixXMLStream(Common::SeekableReadStream &i
  * Convert the input stream to a vector of elements.
  */
 void XMLFixer::readXMLStream(Common::SeekableReadStream &in) {
-	Common::UString::iterator it;
+	Common::UString::iterator it1, it2;
 	Common::UString line, buffer;
 	bool openTag = false;
 	bool priorTag  = false;
@@ -84,6 +84,15 @@ void XMLFixer::readXMLStream(Common::SeekableReadStream &in) {
 		// Read a line of text
 		line = Common::readStringLine(in, encoding);
 		line.trim(); // Trim now for maximum performance benefit
+
+		// Check for comment tags
+		it1 = line.findFirst("<!--");
+		it2 = line.findFirst("-->");
+		if (it1 != line.end() && it2 != line.end()) {
+			// Remove appended comment
+			line.erase(it1, it2);
+			line.trimRight();
+		}
 
 		// Check for an end tag
 		openTag = !isTagClose(line);

--- a/src/aurora/xmlfixer.cpp
+++ b/src/aurora/xmlfixer.cpp
@@ -91,7 +91,7 @@ Common::SeekableReadStream *XMLFixer::fixXMLStream(Common::SeekableReadStream &i
  * Bring the element into a valid XML form
  */
 Common::UString XMLFixer::fixXMLElement(const Common::UString element) {
-	Common::UString line, name, value;
+	Common::UString line;
 	SegmentList segments;
 
 	// Split on the equals sign
@@ -106,10 +106,19 @@ Common::UString XMLFixer::fixXMLElement(const Common::UString element) {
 	// Cycle through the segments
 	line = "";
 	for (SegmentList::iterator it1 = segments.begin(); it1 != segments.end(); ++it1) {
-		// Find the last space character
-		Common::UString::iterator it2 = it1->findLast(' ');
-		name = it1->substr(it2, it1->end());
-		value = it1->substr(it1->begin(), it2);
+		Common::UString name, value;
+		name = "";
+		value = *it1;
+
+		// Find the last white space character
+		Common::UString::iterator it2 = it1->end();
+		do {
+			--it2;
+			if (it1->isSpace(*it2)) {
+				it1->split(it2, value, name, true);
+				break;
+			}
+		} while(it2 != it1->begin());
 
 		// Trim both parts
 		name.trim();

--- a/src/aurora/xmlfixer.cpp
+++ b/src/aurora/xmlfixer.cpp
@@ -90,8 +90,31 @@ Common::SeekableReadStream *XMLFixer::fixXMLStream(Common::SeekableReadStream &i
 /**
  * Bring the element into a valid XML form
  */
-Common::UString XMLFixer::fixXMLElement(Common::UString element) {
-	Common::UString line = element;
+Common::UString XMLFixer::fixXMLElement(const Common::UString element) {
+	Common::UString line;
+	SegmentList segments;
+
+	// Split on the equals sign
+	line.split(element, (uint32)'=', segments);
+
+	// If there is only one segment, just return it
+	if (segments.size() < 2) {
+		line = element;
+		return line;
+	}
+
+	// Cycle through the segments
+	line = "";
+	for (SegmentList::iterator it = segments.begin(); it != segments.end(); ++it) {
+		// Parse each segment for the last space character
+		if (line.size() == 0) {
+			// First segment should be the element type
+			line = *it;
+		} else {
+			// Subsequent segment
+			line += "=" + *it;
+		}
+	}
 
 	return line;
 }

--- a/src/aurora/xmlfixer.cpp
+++ b/src/aurora/xmlfixer.cpp
@@ -113,18 +113,22 @@ Common::UString XMLFixer::fixXMLElement(const Common::UString element) {
 	line = "";
 	for (SegmentList::iterator it1 = segments.begin(); it1 != segments.end(); ++it1) {
 		// Initialization
+		Common::UString segment = *it1;
 		name = "";
 		value = *it1;
 
+		// Correct for " = " in playermenu_popup.xml
+		segment.trim();
+
 		// Find the last white space character
-		Common::UString::iterator it2 = it1->end();
+		Common::UString::iterator it2 = segment.end();
 		do {
 			--it2;
-			if (it1->isSpace(*it2)) {
-				it1->split(it2, value, name, true);
+			if (segment.isSpace(*it2)) {
+				segment.split(it2, value, name, true);
 				break;
 			}
-		} while (it2 != it1->begin());
+		} while (it2 != segment.begin());
 
 		// Trim both parts
 		name.trim();

--- a/src/aurora/xmlfixer.h
+++ b/src/aurora/xmlfixer.h
@@ -49,6 +49,7 @@ private:
 
 	bool isTagClose(const Common::UString value);
 	bool isValidXMLHeader(Common::SeekableReadStream &in);
+	bool isFixSpecialCase(Common::UString *value);
 	void readXMLStream(Common::SeekableReadStream &in, ElementList *elements);
 	Common::UString fixXMLElement(const Common::UString element);
 	Common::UString fixXMLValue(const Common::UString value);

--- a/src/aurora/xmlfixer.h
+++ b/src/aurora/xmlfixer.h
@@ -43,8 +43,10 @@ public:
 	static Common::SeekableReadStream *fixXMLStream(Common::SeekableReadStream &in);
 
 private:
+	typedef std::vector<Common::UString>	ElementList;
+
 	bool isTagClose(Common::UString line);
-	void readXMLStream(Common::SeekableReadStream &in);
+	void readXMLStream(Common::SeekableReadStream &in, ElementList *elements);
 	void readXMLHeader(Common::SeekableReadStream &in);
 };
 

--- a/src/aurora/xmlfixer.h
+++ b/src/aurora/xmlfixer.h
@@ -49,6 +49,7 @@ private:
 	bool isTagClose(Common::UString line);
 	bool isValidXMLHeader(Common::SeekableReadStream &in);
 	void readXMLStream(Common::SeekableReadStream &in, ElementList *elements);
+	Common::UString fixXMLElement(Common::UString element);
 };
 
 } // End of namespace Aurora

--- a/src/aurora/xmlfixer.h
+++ b/src/aurora/xmlfixer.h
@@ -55,6 +55,7 @@ private:
 	Common::UString fixXMLValue(const Common::UString value);
 	Common::UString stripEndQuotes(const Common::UString value);
 	Common::UString fixParams(const Common::UString params);
+	void splitNewElement(Common::UString *value, Common::UString *tail);
 };
 
 } // End of namespace Aurora

--- a/src/aurora/xmlfixer.h
+++ b/src/aurora/xmlfixer.h
@@ -51,6 +51,7 @@ private:
 	bool isValidXMLHeader(Common::SeekableReadStream &in);
 	void readXMLStream(Common::SeekableReadStream &in, ElementList *elements);
 	Common::UString fixXMLElement(const Common::UString element);
+	Common::UString fixXMLValue(const Common::UString value);
 };
 
 } // End of namespace Aurora

--- a/src/aurora/xmlfixer.h
+++ b/src/aurora/xmlfixer.h
@@ -33,6 +33,7 @@
 namespace Common {
 	class Ustring;
 	class SeekableReadStream;
+	class MemoryWriteStreamDynamic;
 }
 
 namespace Aurora {
@@ -46,8 +47,7 @@ private:
 	typedef std::vector<Common::UString>	ElementList;
 
 	bool isTagClose(Common::UString line);
-	Common::UString readXMLHeader(Common::SeekableReadStream &in);
-	Common::UString fixXMLHeader(Common::UString header);
+	bool isValidXMLHeader(Common::SeekableReadStream &in);
 	void readXMLStream(Common::SeekableReadStream &in, ElementList *elements);
 };
 

--- a/src/aurora/xmlfixer.h
+++ b/src/aurora/xmlfixer.h
@@ -44,8 +44,8 @@ public:
 	static Common::SeekableReadStream *fixXMLStream(Common::SeekableReadStream &in);
 
 private:
-	typedef std::vector<Common::UString>	ElementList;
-	typedef std::vector<Common::UString>	SegmentList;
+	typedef std::vector<Common::UString> ElementList;
+	typedef std::vector<Common::UString> SegmentList;
 
 	bool isTagClose(const Common::UString value);
 	bool isValidXMLHeader(Common::SeekableReadStream &in);

--- a/src/aurora/xmlfixer.h
+++ b/src/aurora/xmlfixer.h
@@ -47,11 +47,13 @@ private:
 	typedef std::vector<Common::UString>	ElementList;
 	typedef std::vector<Common::UString>	SegmentList;
 
-	bool isTagClose(Common::UString line);
+	bool isTagClose(const Common::UString value);
 	bool isValidXMLHeader(Common::SeekableReadStream &in);
 	void readXMLStream(Common::SeekableReadStream &in, ElementList *elements);
 	Common::UString fixXMLElement(const Common::UString element);
 	Common::UString fixXMLValue(const Common::UString value);
+	Common::UString stripEndQuotes(const Common::UString value);
+	Common::UString fixFunction(const Common::UString function, const Common::UString::iterator it);
 };
 
 } // End of namespace Aurora

--- a/src/aurora/xmlfixer.h
+++ b/src/aurora/xmlfixer.h
@@ -46,8 +46,9 @@ private:
 	typedef std::vector<Common::UString>	ElementList;
 
 	bool isTagClose(Common::UString line);
+	Common::UString readXMLHeader(Common::SeekableReadStream &in);
+	Common::UString fixXMLHeader(Common::UString header);
 	void readXMLStream(Common::SeekableReadStream &in, ElementList *elements);
-	void readXMLHeader(Common::SeekableReadStream &in);
 };
 
 } // End of namespace Aurora

--- a/src/aurora/xmlfixer.h
+++ b/src/aurora/xmlfixer.h
@@ -1,0 +1,44 @@
+/* xoreos-tools - Tools to help with xoreos development
+ *
+ * xoreos-tools is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos-tools is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos-tools is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos-tools. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Fix broken, non-standard NWN2 XML files.
+ */
+
+#ifndef AURORA_XMLFIX_H
+#define AURORA_XMLFIX_H
+
+#include <iostream>
+
+namespace Common {
+	class SeekableReadStream;
+}
+
+namespace Aurora {
+
+class XMLFixer {
+
+public:
+	static Common::SeekableReadStream *fixXMLStream(Common::SeekableReadStream &in);
+};
+
+} // End of namespace Aurora
+
+#endif // AURORA_XMLFIX_H

--- a/src/aurora/xmlfixer.h
+++ b/src/aurora/xmlfixer.h
@@ -56,6 +56,7 @@ private:
 	Common::UString stripEndQuotes(const Common::UString value);
 	Common::UString fixParams(const Common::UString params);
 	void splitNewElement(Common::UString *value, Common::UString *tail);
+	bool isBadUIButtonRange(const Common::UString line, int *buttonCount);
 };
 
 } // End of namespace Aurora

--- a/src/aurora/xmlfixer.h
+++ b/src/aurora/xmlfixer.h
@@ -43,6 +43,7 @@ public:
 	static Common::SeekableReadStream *fixXMLStream(Common::SeekableReadStream &in);
 
 private:
+	bool isTagClose(Common::UString line);
 	void readXMLStream(Common::SeekableReadStream &in);
 	void readXMLHeader(Common::SeekableReadStream &in);
 };

--- a/src/aurora/xmlfixer.h
+++ b/src/aurora/xmlfixer.h
@@ -54,7 +54,7 @@ private:
 	Common::UString fixXMLElement(const Common::UString element);
 	Common::UString fixXMLValue(const Common::UString value);
 	Common::UString stripEndQuotes(const Common::UString value);
-	Common::UString fixFunction(const Common::UString function, const Common::UString::iterator it);
+	Common::UString fixParams(const Common::UString params);
 };
 
 } // End of namespace Aurora

--- a/src/aurora/xmlfixer.h
+++ b/src/aurora/xmlfixer.h
@@ -26,8 +26,12 @@
 #define AURORA_XMLFIX_H
 
 #include <iostream>
+#include <string>
+
+#include "src/common/ustring.h"
 
 namespace Common {
+	class Ustring;
 	class SeekableReadStream;
 }
 
@@ -37,6 +41,10 @@ class XMLFixer {
 
 public:
 	static Common::SeekableReadStream *fixXMLStream(Common::SeekableReadStream &in);
+
+private:
+	void readXMLStream(Common::SeekableReadStream &in);
+	void readXMLHeader(Common::SeekableReadStream &in);
 };
 
 } // End of namespace Aurora

--- a/src/aurora/xmlfixer.h
+++ b/src/aurora/xmlfixer.h
@@ -45,11 +45,12 @@ public:
 
 private:
 	typedef std::vector<Common::UString>	ElementList;
+	typedef std::vector<Common::UString>	SegmentList;
 
 	bool isTagClose(Common::UString line);
 	bool isValidXMLHeader(Common::SeekableReadStream &in);
 	void readXMLStream(Common::SeekableReadStream &in, ElementList *elements);
-	Common::UString fixXMLElement(Common::UString element);
+	Common::UString fixXMLElement(const Common::UString element);
 };
 
 } // End of namespace Aurora

--- a/src/common/ustring.cpp
+++ b/src/common/ustring.cpp
@@ -375,7 +375,7 @@ void UString::trim() {
 	iterator itEnd = --end();
 	for (; itEnd != begin(); --itEnd) {
 		uint32 c = *itEnd;
-		if ((c != '\0') && (c != ' ')) {
+		if (!isSpace(c) && (c != '\0')) {
 			++itEnd;
 			break;
 		}
@@ -383,14 +383,14 @@ void UString::trim() {
 
 	if (itEnd == begin()) {
 		uint32 c = *itEnd;
-		if ((c != '\0') && (c != ' '))
+		if (!isSpace(c) && (c != '\0'))
 			++itEnd;
 	}
 
 	// Find the first non-space
 	iterator itStart = begin();
 	for (; itStart != itEnd; ++itStart)
-		if (*itStart != ' ')
+		if (!isSpace(*itStart))
 			break;
 
 	_string = std::string(itStart.base(), itEnd.base());
@@ -405,7 +405,7 @@ void UString::trimLeft() {
 	// Find the first non-space
 	iterator itStart = begin();
 	for (; itStart != end(); ++itStart)
-		if (*itStart != ' ')
+		if (!isSpace(*itStart))
 			break;
 
 	_string = std::string(itStart.base(), end().base());
@@ -421,7 +421,7 @@ void UString::trimRight() {
 	iterator itEnd = --end();
 	for (; itEnd != begin(); --itEnd) {
 		uint32 c = *itEnd;
-		if ((c != '\0') && (c != ' ')) {
+		if (!isSpace(c) && (c != '\0')) {
 			++itEnd;
 			break;
 		}
@@ -429,7 +429,7 @@ void UString::trimRight() {
 
 	if (itEnd == begin()) {
 		uint32 c = *itEnd;
-		if ((c != '\0') && (c != ' '))
+		if (!isSpace(c) && (c != '\0'))
 			++itEnd;
 	}
 

--- a/src/common/ustring.cpp
+++ b/src/common/ustring.cpp
@@ -338,6 +338,13 @@ bool UString::contains(uint32 c) const {
 	return findFirst(c) != end();
 }
 
+uint32 UString::at(size_t pos) const {
+	if (pos < _size)
+		return _string.at(pos);
+	else
+		return 0;
+}
+
 void UString::truncate(const iterator &it) {
 	UString temp;
 

--- a/src/common/ustring.h
+++ b/src/common/ustring.h
@@ -135,6 +135,8 @@ public:
 	bool contains(const UString &what) const;
 	bool contains(uint32 c) const;
 
+	uint32 at(size_t pos) const;
+
 	void truncate(const iterator &it);
 	void truncate(size_t n);
 

--- a/src/fixnwn2xml.cpp
+++ b/src/fixnwn2xml.cpp
@@ -1,0 +1,82 @@
+/* xoreos-tools - Tools to help with xoreos development
+ *
+ * xoreos-tools is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos-tools is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos-tools is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos-tools. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ * Command-line tool to fix broken, non-standard NWN2 XML files.
+ */
+
+#include <iostream>
+#include <string>
+#include <fstream>
+#include <algorithm>
+#include <stdio.h>
+#include <ctype.h>
+
+#include "src/util.h"
+
+#include "src/common/scopedptr.h"
+#include "src/common/ustring.h"
+#include "src/common/util.h"
+#include "src/common/error.h"
+#include "src/common/platform.h"
+#include "src/common/cli.h"
+#include "src/common/readfile.h"
+#include "src/common/writefile.h"
+#include "src/common/filepath.h"
+#include "src/common/memreadstream.h"
+
+#include "src/aurora/xmlfixer.h"
+
+bool parseCommandLine(const std::vector<Common::UString> &argv, int &returnValue,
+                      Common::UString &inFile, Common::UString &outFile);
+
+
+int main(int argc, char **argv) {
+	initPlatform();
+
+	try {
+		std::vector<Common::UString> args;
+		Common::Platform::getParameters(argc, argv, args);
+
+		int returnValue = 1;
+		Common::UString inFile, outFile;
+
+		if (!parseCommandLine(args, returnValue, inFile, outFile))
+			return returnValue;
+	} catch (...) {
+		Common::exceptionDispatcherError();
+	}
+
+	return 0;
+}
+
+bool parseCommandLine(const std::vector<Common::UString> &argv, int &returnValue,
+                      Common::UString &inFile, Common::UString &outFile) {
+	using Common::CLI::Parser;
+	using Common::CLI::ValGetter;
+	using Common::CLI::NoOption;
+	using Common::CLI::makeEndArgs;
+	std::vector<Common::CLI::Getter *> getters;
+	NoOption inFileOpt(false, new ValGetter<Common::UString &>(inFile, "input file"));
+	NoOption outFileOpt(true, new ValGetter<Common::UString &>(outFile, "output file"));
+	Parser parser(argv[0], "Convert NWN2 XML file to standard XML format", "", returnValue,
+                      makeEndArgs(&inFileOpt, &outFileOpt));
+	return parser.process(argv);
+}

--- a/src/fixnwn2xml.cpp
+++ b/src/fixnwn2xml.cpp
@@ -41,11 +41,14 @@
 #include "src/common/writefile.h"
 #include "src/common/filepath.h"
 #include "src/common/memreadstream.h"
+#include "src/common/stdoutstream.h"
 
 #include "src/aurora/xmlfixer.h"
 
 bool parseCommandLine(const std::vector<Common::UString> &argv, int &returnValue,
                       Common::UString &inFile, Common::UString &outFile);
+
+void convert(Common::UString &inFile, Common::UString &outFile);
 
 
 int main(int argc, char **argv) {
@@ -60,6 +63,8 @@ int main(int argc, char **argv) {
 
 		if (!parseCommandLine(args, returnValue, inFile, outFile))
 			return returnValue;
+
+		convert(inFile, outFile);
 	} catch (...) {
 		Common::exceptionDispatcherError();
 	}
@@ -80,3 +85,23 @@ bool parseCommandLine(const std::vector<Common::UString> &argv, int &returnValue
                       makeEndArgs(&inFileOpt, &outFileOpt));
 	return parser.process(argv);
 }
+
+/*
+ * Read in the input file, apply XML format corrections, then write to output file.
+ */
+void convert(Common::UString &inFile, Common::UString &outFile) {
+	// Read the input file into memory
+	Common::ScopedPtr<Common::SeekableReadStream> in(Common::ReadFile::readIntoMemory(inFile));
+	Common::ScopedPtr<Common::WriteStream> out(openFileOrStdOut(outFile));
+
+	// Filter the input
+	Common::ReadStream *fixed = Aurora::XMLFixer::fixXMLStream(*in);
+
+	// Write to output
+	out->writeStream(*fixed);
+	out->flush();
+
+	if (!outFile.empty())
+		status("Converted \"%s\" to \"%s\"", inFile.c_str(), outFile.c_str());
+}
+

--- a/src/rules.mk
+++ b/src/rules.mk
@@ -27,6 +27,18 @@ noinst_HEADERS += \
 
 # The individual tools
 
+bin_PROGRAMS += src/fixnwn2xml
+src_fixnwn2xml_SOURCES = \
+    src/fixnwn2xml.cpp \
+    src/util.cpp \
+    $(EMPTY)
+src_fixnwn2xml_LDADD = \
+    src/aurora/libaurora.la \
+    src/common/libcommon.la \
+    src/version/libversion.la \
+    $(LDADD) \
+    $(EMPTY)
+
 bin_PROGRAMS += src/gff2xml
 src_gff2xml_SOURCES = \
     src/gff2xml.cpp \

--- a/tests/aurora/rules.mk
+++ b/tests/aurora/rules.mk
@@ -115,3 +115,8 @@ check_PROGRAMS                      += tests/aurora/test_erfwriter
 tests_aurora_test_erfwriter_SOURCES  = tests/aurora/erfwriter.cpp
 tests_aurora_test_erfwriter_LDADD    = $(aurora_LIBS)
 tests_aurora_test_erfwriter_CXXFLAGS = $(test_CXXFLAGS)
+
+check_PROGRAMS                      += tests/aurora/test_xmlfixer
+tests_aurora_test_xmlfixer_SOURCES   = tests/aurora/xmlfixer.cpp
+tests_aurora_test_xmlfixer_LDADD     = $(aurora_LIBS)
+tests_aurora_test_xmlfixer_CXXFLAGS  = $(test_CXXFLAGS)

--- a/tests/aurora/xmlfixer.cpp
+++ b/tests/aurora/xmlfixer.cpp
@@ -1,0 +1,100 @@
+/* xoreos-tools - Tools to help with xoreos development
+ *
+ * xoreos-tools is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos-tools is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos-tools is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos-tools. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Unit test for the NWN2 XML validation fix
+ */
+
+#include "gtest/gtest.h"
+
+#include "src/common/util.h"
+#include "src/common/error.h"
+#include "src/common/memreadstream.h"
+
+#include "src/aurora/xmlfixer.h"
+
+// Invalid NWN2 XML
+static const char *kDataInvalid =
+	"abc<?xml version=\"1.0\" encoding=\"NWN2UI\">\n"
+	"<!-- Copyright 2006 Obsidian Entertainment, Inc. -->\n"
+	"\n"
+	"\t<!--\n"
+	"\t\t-- double dash\n"
+	"\t-->\n"
+	"\n"
+	"<UIScene name=\"FOOBAR\" fadeout=\"0.3\" fadein=\"0.3\" x=0 y=0 fullscreen=true\n"
+	"\t width=SCREEN_WIDTH height=SCREEN_HEIGHT\n"
+	"\t OnAdd=UIScene_OnAdd_SetUpServerOptions( \n"
+	"\t OnRemove=UIScene_OnRemove_SaveServerOptions()\n"
+	"\t priority=\"SCENE_FE_FULLSCREEN\" \n"
+	"\t /> <!-- Appended comment -->\n"
+	"\n"
+	"\t\t<UIText name=\"IDENTIFY_TEXT\" width=PARENT_WIDTH height=PARENT_HEIGHT align=center valign=middle uppercase=truefontfamily=\"Default\" style=\"bold\" />\n"
+	"\n"
+	"\t<UIText name=\"PreHorizonB\" strref=\"181357\"\" x=5 y=368 width=90\" height=16 valign=\"middle align=LEFT fontfamily=\"Special_Font\" style=\"1\"  />\n"
+	"\n"
+	"\t</UIButton>\n"
+	"\t<UIButton name=\"CAMERA_ZOOM_OUT\" x=\"0\" y=\"0\" width=\"35\" height=\"34\" buttontype=\"radio\" groupid=\"2\" groupmemberid=\"1\" DefaultToolTip=\"181294\"\n"
+	"\t\t\tOnSelected=UIButton_Input_Move3DCamera(\"TEMP_CHARACTER_SCENE\",\"PLAYER_CREATURE\",\"SET_POSITION\",\"-1.25\",\"0.0\",\"1.3\",\"-0.90\",\"4.0\",\"1.1\",\"0.5\")\n"
+	"\t\t\tOnToolTip=UIObject_Tooltip_DisplayObject(OBJECT_X,OBJECT_Y,SCREEN_TOOLTIP_2,ALIGN_NONE,ALIGN_NONE,0,0,ALIGN_LEFT\") >\n"
+	"\n"
+	"<!--\n"
+	"(W) for ?whisper?\n"
+	"-->\n"
+	"\n"
+	"</UIButton>\n"
+	"<UIButton name=\"LOCAL SAY\" buttontype=radio groupid=1 groupmemberid=1 \n"
+	"\tOnSelected=UIButton_Input_SetChatMode(0) style=\"CHAT_MODE_BUTTON\"    text=\"L\"\n"
+	"\tOnToolTip=UIObject_Tooltip_DisplayTooltipStringRef(184736,\"OBJECT_X\",\"OBJECT_Y\",\"SCREEN_TOOLTIP_2\") />\n"
+	"\n"
+	"\t<UIButton name=\"DUNGEON MASTER\" buttontype=\"radio\" groupid=\"1\" groupmemberid=\"4\" \n"
+	"\t\tOnSelected=UIButton_Input_SetChatMode(3) style=\"CHAT_MODE_BUTTON\"  text=\"D\"\n"
+	"\t\tOnToolTip=UIObject_Tooltip_DisplayTooltipStringRef(184739,\"OBJECT_X\",OBJECT_Y,\"SCREEN_TOOLTIP_2\") />\n"
+	"\n";
+
+// Valid XML
+static const char *kDataValid =
+	"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+	"<Root>\n"
+	"<UIScene name=\"FOOBAR\" fadeout=\"0.3\" fadein=\"0.3\" x=\"0\" y=\"0\" fullscreen=\"true\" width=\"SCREEN_WIDTH\" height=\"SCREEN_HEIGHT\" OnAdd=\"UIScene_OnAdd_SetUpServerOptions()\" OnRemove=\"UIScene_OnRemove_SaveServerOptions()\" priority=\"SCENE_FE_FULLSCREEN\" />\n"
+	"<UIText name=\"IDENTIFY_TEXT\" width=\"PARENT_WIDTH\" height=\"PARENT_HEIGHT\" align=\"center\" valign=\"middle\" uppercase=\"true\" fontfamily=\"Default\" style=\"bold\" />\n"
+	"<UIText name=\"PreHorizonB\" strref=\"181357\" x=\"5\" y=\"368\" width=\"90\" height=\"16\" valign=\"middle\" align=\"LEFT\" fontfamily=\"Special_Font\" style=\"1\" />\n"
+	"<!-- </UIButton>-->\n"
+	"<UIButton name=\"CAMERA_ZOOM_OUT\" x=\"0\" y=\"0\" width=\"35\" height=\"34\" buttontype=\"radio\" groupid=\"2\" groupmemberid=\"1\" DefaultToolTip=\"181294\" OnSelected=\"UIButton_Input_Move3DCamera(&quot;TEMP_CHARACTER_SCENE&quot;,&quot;PLAYER_CREATURE&quot;,&quot;SET_POSITION&quot;,&quot;-1.25&quot;,&quot;0.0&quot;,&quot;1.3&quot;,&quot;-0.90&quot;,&quot;4.0&quot;,&quot;1.1&quot;,&quot;0.5&quot;)\" OnToolTip=\"UIObject_Tooltip_DisplayObject(&quot;OBJECT_X&quot;,&quot;OBJECT_Y&quot;,&quot;SCREEN_TOOLTIP_2&quot;,&quot;ALIGN_NONE&quot;,&quot;ALIGN_NONE&quot;,&quot;0&quot;,&quot;0&quot;,&quot;ALIGN_LEFT&quot;)\" >\n"
+	"</UIButton>\n"
+	"<UIButton name=\"LOCAL SAY\" buttontype=\"radio\" groupid=\"1\" groupmemberid=\"1\" OnSelected=\"UIButton_Input_SetChatMode(&quot;0&quot;)\" style=\"CHAT_MODE_BUTTON\" text=\"L\" OnToolTip=\"UIObject_Tooltip_DisplayTooltipStringRef(&quot;184736&quot;,&quot;OBJECT_X&quot;,&quot;OBJECT_Y&quot;,&quot;SCREEN_TOOLTIP_2&quot;)\" />\n"
+	"<UIButton name=\"DUNGEON MASTER\" buttontype=\"radio\" groupid=\"1\" groupmemberid=\"4\" OnSelected=\"UIButton_Input_SetChatMode(&quot;3&quot;)\" style=\"CHAT_MODE_BUTTON\" text=\"D\" OnToolTip=\"UIObject_Tooltip_DisplayTooltipStringRef(&quot;184739&quot;,&quot;OBJECT_X&quot;,&quot;OBJECT_Y&quot;,&quot;SCREEN_TOOLTIP_2&quot;)\" />\n"
+	"</Root>\n";
+
+GTEST_TEST(xmlFixer, fixXMLStream) {
+	Common::SeekableReadStream *invalid = new Common::MemoryReadStream(kDataInvalid);
+
+	Aurora::XMLFixer converter;
+	Common::SeekableReadStream *valid = converter.fixXMLStream(*invalid);
+	ASSERT_EQ(valid->size(), strlen(kDataValid));
+
+	for (size_t i = 0; i < strlen(kDataValid); i++) {
+		EXPECT_EQ(valid->readByte(), kDataValid[i]) << "At index " << i;
+	}
+
+	delete invalid;
+	delete valid;
+}
+

--- a/tests/common/ustring.cpp
+++ b/tests/common/ustring.cpp
@@ -296,6 +296,22 @@ GTEST_TEST(UString, containsString) {
 	EXPECT_FALSE(str.contains("Qux"));
 }
 
+GTEST_TEST(UString, at) {
+	const Common::UString str("Foobar Barfoo");
+
+	uint32 f = str.at(0);
+	uint32 b = str.at(7);
+	uint32 r = str.at(9);
+	uint32 o = str.at(12);
+	uint32 e = str.at(13);
+
+	EXPECT_EQ(f, 'F');
+	EXPECT_EQ(b, 'B');
+	EXPECT_EQ(r, 'r');
+	EXPECT_EQ(o, 'o');
+	EXPECT_EQ(e, 0);
+}
+
 GTEST_TEST(UString, truncateInt) {
 	Common::UString str("Foobar Barfoo");
 


### PR DESCRIPTION
This pull provides the class XMLFix, which can accept a
SeekableReadStream containing the contents of a NWN2 XML file and
return a SeekableReadStream with the XML in a valid form. This can
be exercised with the included fix2xml.exe build, which reads in a
NWN2 XML file and outputs a corrected XML file. The latter tool was
used to bulk test the stock NWN2 XML files and the XML files from
some NWN2 mods. The result was processed with a call to
'xmllint --noout filename.xml' to check for valid XML. All of the
converted test files passed validation.

The mods used to test the class were:

Tchos' HD UI panels and dialogue compilation and expansion
SlimGUI
Black UI
Kaldor Silverwand Context Menu Additions
I manually checked a sample of the output files looking for
irregularities, and these have been corrected.

The code required the addition of an at() call to the UString class
and a modification of the UString::trim* functions to check for
whitespace characters rather than just ' '.

Finally, it includes a unit test for producing valid XML output.