### PR TITLE
GFF2XML: Adding 'RST ' GFF type for NWN2 roster files

### DIFF
--- a/src/xml/gffdumper.cpp
+++ b/src/xml/gffdumper.cpp
@@ -72,6 +72,7 @@ static const uint32 kGFFTypes[] = {
 	MKTAG('Q', 'D', 'B', ' '),
 	MKTAG('Q', 'S', 'T', ' '),
 	MKTAG('R', 'E', 'S', ' '),
+	MKTAG('R', 'S', 'T', ' '),
 	MKTAG('S', 'A', 'V', ' '),
 	MKTAG('S', 'N', 'P', ' '),
 	MKTAG('S', 'T', 'O', ' '),


### PR DESCRIPTION
I verified that the updated tool works with a ROSTER.rst file
copied from a NWN2 OC save.