### PR TITLE
NWSCRIPT: Correct string representation of GETREFARRAY opcode

### DIFF
--- a/src/nwscript/util.cpp
+++ b/src/nwscript/util.cpp
@@ -48,7 +48,7 @@ static const char * const kOpcodeName[kOpcodeMAX] = {
 	/* 0x2C */ "STORESTATE",    "NOP",         "??",        "??",
 	/* 0x30 */ "WRITEARRAY",    "??",          "READARRAY", "??",
 	/* 0x34 */ "??",            "??",          "??",        "GETREF",
-	/* 0x38 */ "??",            "GETARRAYREF", "??",        "??",
+	/* 0x38 */ "??",            "GETREFARRAY", "??",        "??",
 	/* 0x3C */ "??",            "??",          "??",        "??",
 	/* 0x40 */ "??",            "??",          "SCRIPTSIZE"
 };


### PR DESCRIPTION
The opcode is actually known as GETREFARRAY, not GETARRAYREF.