### PR TITLE
fix "Missing encoding" when call xml2tlk

### DIFF
--- a/src/xml2tlk.cpp
+++ b/src/xml2tlk.cpp
@@ -129,60 +129,42 @@ bool parseCommandLine(const std::vector<Common::UString> &argv, int &returnValue
 
 	parser.addSpace();
 	parser.addOption("cp1250", "Write TLK strings as Windows CP-1250", kContinueParsing,
-	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingCP1250, encoding),
-	                 new ValAssigner<GameID>(Aurora::kGameIDUnknown, game)));
+	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingCP1250, encoding)));
 	parser.addOption("cp1251", "Write TLK strings as Windows CP-1251", kContinueParsing,
-	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingCP1251, encoding),
-	                 new ValAssigner<GameID>(Aurora::kGameIDUnknown, game)));
+	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingCP1251, encoding)));
 	parser.addOption("cp1252", "Write TLK strings as Windows CP-1252", kContinueParsing,
-	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingCP1252, encoding),
-	                 new ValAssigner<GameID>(Aurora::kGameIDUnknown, game)));
+	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingCP1252, encoding)));
 	parser.addOption("cp932", "Write TLK strings as Windows CP-932", kContinueParsing,
-	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingCP932, encoding),
-	                 new ValAssigner<GameID>(Aurora::kGameIDUnknown, game)));
+	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingCP932, encoding)));
 	parser.addOption("cp936", "Write TLK strings as Windows CP-936", kContinueParsing,
-	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingCP936, encoding),
-	                 new ValAssigner<GameID>(Aurora::kGameIDUnknown, game)));
+	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingCP936, encoding)));
 	parser.addOption("cp949", "Write TLK strings as Windows CP-949", kContinueParsing,
-	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingCP949, encoding),
-	                 new ValAssigner<GameID>(Aurora::kGameIDUnknown, game)));
+	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingCP949, encoding)));
 	parser.addOption("cp950", "Write TLK strings as Windows CP-950", kContinueParsing,
-	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingCP950, encoding),
-	                 new ValAssigner<GameID>(Aurora::kGameIDUnknown, game)));
+	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingCP950, encoding)));
 	parser.addOption("utf8", "Write TLK strings as UTF-8", kContinueParsing,
-	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingUTF8, encoding),
-	                 new ValAssigner<GameID>(Aurora::kGameIDUnknown, game)));
+	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingUTF8, encoding)));
 	parser.addOption("utf16le", "Write TLK strings as little-endian UTF-16", kContinueParsing,
-	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingUTF16LE, encoding),
-	                 new ValAssigner<GameID>(Aurora::kGameIDUnknown, game)));
+	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingUTF16LE, encoding)));
 	parser.addOption("utf16be", "Write TLK strings as big-endian UTF-16", kContinueParsing,
-	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingUTF16BE, encoding),
-	                 new ValAssigner<GameID>(Aurora::kGameIDUnknown, game)));
+	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingUTF16BE, encoding)));
 	parser.addSpace();
 	parser.addOption("nwn", "Use Neverwinter Nights encodings", kContinueParsing,
-	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingInvalid, encoding),
-	                 new ValAssigner<GameID>(Aurora::kGameIDNWN, game)));
+	                 makeAssigners(new ValAssigner<GameID>(Aurora::kGameIDNWN, game)));
 	parser.addOption("nwn2", "Use Neverwinter Nights 2 encodings", kContinueParsing,
-	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingInvalid, encoding),
-	                 new ValAssigner<GameID>(Aurora::kGameIDNWN2, game)));
+	                 makeAssigners(new ValAssigner<GameID>(Aurora::kGameIDNWN2, game)));
 	parser.addOption("kotor", "Use Knights of the Old Republic encodings", kContinueParsing,
-	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingInvalid, encoding),
-	                 new ValAssigner<GameID>(Aurora::kGameIDKotOR, game)));
+	                 makeAssigners(new ValAssigner<GameID>(Aurora::kGameIDKotOR, game)));
 	parser.addOption("kotor2", "Use Knights of the Old Republic II encodings", kContinueParsing,
-	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingInvalid, encoding),
-	                 new ValAssigner<GameID>(Aurora::kGameIDKotOR2, game)));
+	                 makeAssigners(new ValAssigner<GameID>(Aurora::kGameIDKotOR2, game)));
 	parser.addOption("jade", "Use Jade Empire encodings", kContinueParsing,
-	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingInvalid, encoding),
-	                 new ValAssigner<GameID>(Aurora::kGameIDJade, game)));
+	                 makeAssigners(new ValAssigner<GameID>(Aurora::kGameIDJade, game)));
 	parser.addOption("witcher", "Use The Witcher encodings", kContinueParsing,
-	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingInvalid, encoding),
-	                 new ValAssigner<GameID>(Aurora::kGameIDWitcher, game)));
+	                 makeAssigners(new ValAssigner<GameID>(Aurora::kGameIDWitcher, game)));
 	parser.addOption("dragonage", "Use Dragon Age encodings", kContinueParsing,
-	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingInvalid, encoding),
-	                 new ValAssigner<GameID>(Aurora::kGameIDDragonAge, game)));
+	                 makeAssigners(new ValAssigner<GameID>(Aurora::kGameIDDragonAge, game)));
 	parser.addOption("dragonage2", "Use Dragon Age II encodings", kContinueParsing,
-	                 makeAssigners(new ValAssigner<Encoding>(Common::kEncodingInvalid, encoding),
-	                 new ValAssigner<GameID>(Aurora::kGameIDDragonAge2, game)));
+	                 makeAssigners(new ValAssigner<GameID>(Aurora::kGameIDDragonAge2, game)));
 
 	if (!parser.process(argv))
 		return false;


### PR DESCRIPTION
xml2tlk requires game option set, which cause encoding set to invalid.